### PR TITLE
Make BrowserPanel load Entry.Link if valid, error page if invalid

### DIFF
--- a/src/main/java/seedu/address/ui/BrowserPanel.java
+++ b/src/main/java/seedu/address/ui/BrowserPanel.java
@@ -10,8 +10,8 @@ import javafx.beans.value.ObservableValue;
 import javafx.event.Event;
 import javafx.fxml.FXML;
 import javafx.scene.layout.Region;
-import javafx.scene.web.WebView;
 import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
 import seedu.address.MainApp;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.entry.Entry;
@@ -63,6 +63,8 @@ public class BrowserPanel extends UiPart<Region> {
             case FAILED:
                 logger.warning(String.format("Failed to load %s", location));
                 loadErrorPage();
+                break;
+            default:
                 break;
             }
         });

--- a/src/main/resources/view/error.html
+++ b/src/main/resources/view/error.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <title>Error Occurred</title>
+        <link rel="stylesheet" href="DarkTheme.css">
+    </head>
+
+    <body class="background" style="color: white; font-family: 'Segoe UI', Helvetica, Arial, sans-serif">
+        <h1>An error occurred.</h1>
+        <p>Try:</p>
+        <ul>
+            <li>Checking your Internet connection</li>
+            <li>Verifying the URL is valid</li>
+        </ul>
+    </body>
+</html>

--- a/src/test/java/seedu/address/testutil/TypicalEntries.java
+++ b/src/test/java/seedu/address/testutil/TypicalEntries.java
@@ -17,6 +17,7 @@ import java.util.List;
 
 import seedu.address.model.EntryBook;
 import seedu.address.model.entry.Entry;
+import seedu.address.MainApp;
 
 /**
  * A utility class containing a list of {@code Entry} objects to be used in tests.
@@ -81,6 +82,21 @@ public class TypicalEntries {
             .withPhone("Comment place-holder")
             .withEmail("https://hans.example.com")
             .withAddress("chicago ave")
+            .build();
+
+    // Must have valid link
+    public static final Entry VALID_LINK = new EntryBuilder()
+            .withName("Valid Link")
+            .withPhone("Valid link")
+            .withEmail("file://" + MainApp.class.getResource("/view/BrowserPanelTest/default.html").toExternalForm().substring(5))
+            .withAddress("Valid link")
+            .build();
+    // Must have invalid link
+    public static final Entry INVALID_LINK = new EntryBuilder()
+            .withName("Invalid Link")
+            .withPhone("Invalid link")
+            .withEmail("file:///folder/file.type")
+            .withAddress("Invalid link")
             .build();
 
     // Manually added - Entry's details found in {@code CommandTestUtil}

--- a/src/test/java/seedu/address/testutil/TypicalEntries.java
+++ b/src/test/java/seedu/address/testutil/TypicalEntries.java
@@ -15,9 +15,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import seedu.address.MainApp;
 import seedu.address.model.EntryBook;
 import seedu.address.model.entry.Entry;
-import seedu.address.MainApp;
 
 /**
  * A utility class containing a list of {@code Entry} objects to be used in tests.
@@ -88,7 +88,8 @@ public class TypicalEntries {
     public static final Entry VALID_LINK = new EntryBuilder()
             .withName("Valid Link")
             .withPhone("Valid link")
-            .withEmail("file://" + MainApp.class.getResource("/view/BrowserPanelTest/default.html").toExternalForm().substring(5))
+            .withEmail("file://"
+                    + MainApp.class.getResource("/view/BrowserPanelTest/default.html").toExternalForm().substring(5))
             .withAddress("Valid link")
             .build();
     // Must have invalid link

--- a/src/test/java/seedu/address/ui/BrowserPanelTest.java
+++ b/src/test/java/seedu/address/ui/BrowserPanelTest.java
@@ -2,8 +2,8 @@ package seedu.address.ui;
 
 import static guitests.guihandles.WebViewUtil.waitUntilBrowserLoaded;
 import static org.junit.Assert.assertEquals;
-import static seedu.address.testutil.TypicalEntries.VALID_LINK;
 import static seedu.address.testutil.TypicalEntries.INVALID_LINK;
+import static seedu.address.testutil.TypicalEntries.VALID_LINK;
 
 import java.net.URL;
 

--- a/src/test/java/seedu/address/ui/BrowserPanelTest.java
+++ b/src/test/java/seedu/address/ui/BrowserPanelTest.java
@@ -2,7 +2,7 @@ package seedu.address.ui;
 
 import static guitests.guihandles.WebViewUtil.waitUntilBrowserLoaded;
 import static org.junit.Assert.assertEquals;
-import static seedu.address.testutil.TypicalEntries.ALICE;
+import static seedu.address.testutil.TypicalEntries.*;
 
 import java.net.URL;
 
@@ -27,16 +27,26 @@ public class BrowserPanelTest extends GuiUnitTest {
     }
 
     @Test
-    public void display() throws Exception {
+    public void displayDefaultPage() {
         // default web page
         assertEquals(BrowserPanel.DEFAULT_PAGE, browserPanelHandle.getLoadedUrl());
+    }
 
-        // associated web page of a entry
-        guiRobot.interact(() -> selectedPerson.set(ALICE));
-        URL expectedPersonUrl = new URL(BrowserPanel.SEARCH_PAGE_URL
-            + ALICE.getTitle().fullTitle.replaceAll(" ", "%20"));
-
+    @Test
+    public void displayCorrectPage() throws Exception {
+        // associated web page of a entry with valid link
+        guiRobot.interact(() -> selectedPerson.set(VALID_LINK));
+        URL expectedPersonUrl = new URL(VALID_LINK.getLink().value);
         waitUntilBrowserLoaded(browserPanelHandle);
         assertEquals(expectedPersonUrl, browserPanelHandle.getLoadedUrl());
     }
+
+    @Test
+    public void displayErrorPage() {
+        // associated web page of a entry with invalid link
+        guiRobot.interact(() -> selectedPerson.set(INVALID_LINK));
+        waitUntilBrowserLoaded(browserPanelHandle);
+        assertEquals(BrowserPanel.ERROR_PAGE, browserPanelHandle.getLoadedUrl());
+    }
+
 }

--- a/src/test/java/seedu/address/ui/BrowserPanelTest.java
+++ b/src/test/java/seedu/address/ui/BrowserPanelTest.java
@@ -2,7 +2,8 @@ package seedu.address.ui;
 
 import static guitests.guihandles.WebViewUtil.waitUntilBrowserLoaded;
 import static org.junit.Assert.assertEquals;
-import static seedu.address.testutil.TypicalEntries.*;
+import static seedu.address.testutil.TypicalEntries.VALID_LINK;
+import static seedu.address.testutil.TypicalEntries.INVALID_LINK;
 
 import java.net.URL;
 

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -215,10 +215,10 @@ public abstract class AddressBookSystemTest {
      */
     protected void assertSelectedCardChanged(Index expectedSelectedCardIndex) {
         getPersonListPanel().navigateToCard(getPersonListPanel().getSelectedCardIndex());
-        String selectedCardName = getPersonListPanel().getHandleToSelectedCard().getTitle();
+        String selectedCardLink = getPersonListPanel().getHandleToSelectedCard().getLink();
         URL expectedUrl;
         try {
-            expectedUrl = new URL(BrowserPanel.SEARCH_PAGE_URL + selectedCardName.replaceAll(" ", "%20"));
+            expectedUrl = new URL(selectedCardLink);
         } catch (MalformedURLException mue) {
             throw new AssertionError("URL expected to be valid.", mue);
         }

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -222,7 +222,8 @@ public abstract class AddressBookSystemTest {
         } catch (MalformedURLException mue) {
             throw new AssertionError("URL expected to be valid.", mue);
         }
-        assertEquals(expectedUrl, getBrowserPanel().getLoadedUrl());
+        // assertEquals(expectedUrl, getBrowserPanel().getLoadedUrl());
+        // TODO: make tests work consistently independent of Internet access and installation directory
 
         assertEquals(expectedSelectedCardIndex.getZeroBased(), getPersonListPanel().getSelectedCardIndex());
     }

--- a/src/test/resources/view/BrowserPanelTest/default.html
+++ b/src/test/resources/view/BrowserPanelTest/default.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <link rel="stylesheet" href="DarkTheme.css">
+</head>
+
+<body class="background">
+</body>
+</html>


### PR DESCRIPTION
#### Resolves part of #27 
When an entry is selected, `BrowserPanel` loads its link, or an error page when an error occurs (e.g. no internet, URL invalid).

`assertEquals(expectedUrl, getBrowserPanel().getLoadedUrl())` is removed from `AddressBookSystemTest#assertSelectedCardChanged` so that `TypicalEntries` does not need to contain valid links, as otherwise an invalid link will result in the loaded URL being the path to error page instead of the expected URL. 
However, `BrowserPanelTest` tests for this correct behaviour when loading a valid and invalid (local) link.