### PR TITLE
Architectural refactor to move Storage behind Model

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -63,7 +63,7 @@ public class MainApp extends Application {
 
         model = initModelManager(storage, userPrefs);
 
-        logic = new LogicManager(model, storage);
+        logic = new LogicManager(model);
 
         ui = new UiManager(logic);
     }
@@ -90,7 +90,7 @@ public class MainApp extends Application {
             initialData = new EntryBook();
         }
 
-        return new ModelManager(initialData, userPrefs);
+        return new ModelManager(initialData, userPrefs, storage);
     }
 
     private void initLogging(Config config) {

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -1,6 +1,5 @@
 package seedu.address.logic;
 
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.logging.Logger;
 
@@ -16,36 +15,21 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyEntryBook;
 import seedu.address.model.entry.Entry;
-import seedu.address.storage.Storage;
 
 /**
  * The main LogicManager of the app.
  */
 public class LogicManager implements Logic {
-    public static final String FILE_OPS_ERROR_MESSAGE = "Could not save data to file: ";
     private final Logger logger = LogsCenter.getLogger(LogicManager.class);
 
     private final Model model;
-    private final Storage storage;
     private final CommandHistory history;
     private final EntryBookParser entryBookParser;
 
-    public LogicManager(Model model, Storage storage) {
+    public LogicManager(Model model) {
         this.model = model;
-        this.storage = storage;
         history = new CommandHistory();
         entryBookParser = new EntryBookParser();
-
-        // Save the models' address book to storage whenever it is modified.
-        // In future, this can be moved to Model, but currently Model does not have a reference to Storage.
-        model.getAddressBook().addListener(observable -> {
-            logger.info("Address book modified, saving to file.");
-            try {
-                storage.saveAddressBook(model.getAddressBook());
-            } catch (IOException ioe) {
-                model.setException(new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe));
-            }
-        });
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 
 /**
@@ -18,7 +17,7 @@ public class ClearCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        model.setAddressBook(new EntryBook());
+        model.clearEntryBook();
         model.commitAddressBook();
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/model/EntryBook.java
+++ b/src/main/java/seedu/address/model/EntryBook.java
@@ -100,6 +100,15 @@ public class EntryBook implements ReadOnlyEntryBook {
         indicateModified();
     }
 
+    /**
+     * Adds a entry to the address book.
+     * The entry must not already exist in the address book.
+     */
+    public void clear() {
+        resetData(new EntryBook());
+        indicateModified();
+    }
+
     @Override
     public void addListener(InvalidationListener listener) {
         invalidationListenerManager.addListener(listener);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -8,6 +8,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.entry.Entry;
+import seedu.address.storage.Storage;
 
 /**
  * The API of the Model component.
@@ -25,6 +26,11 @@ public interface Model {
      * Returns the user prefs.
      */
     ReadOnlyUserPrefs getUserPrefs();
+
+    /**
+     * Gets the storage backing this model.
+     */
+    Storage getStorage();
 
     /**
      * Returns the user prefs' GUI settings.
@@ -168,4 +174,11 @@ public interface Model {
      * Sets the command result manually.
      */
     void setCommandResult(CommandResult result);
+
+    /**
+     * Makes a copy of the model.
+     *
+     * Mainly created because clone is needed a lot in tests.
+     */
+    Model clone();
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -78,6 +78,11 @@ public interface Model {
      */
     void setPerson(Entry target, Entry editedEntry);
 
+    /**
+     * Clears the entire entry book.
+     */
+    void clearEntryBook();
+
     /** Returns an unmodifiable view of the filtered entry list */
     ObservableList<Entry> getFilteredPersonList();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -123,6 +123,11 @@ public class ModelManager implements Model {
         versionedAddressBook.setPerson(target, editedEntry);
     }
 
+    @Override
+    public void clearEntryBook() {
+        versionedAddressBook.clear();
+    }
+
     //=========== Filtered Entry List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -57,7 +57,7 @@ public class ModelManager implements Model {
         this.storage = storage;
 
         // Save the entry book to storage whenever it is modified.
-        versionedEntryBook.addListener(this::ensureStorageSaved);
+        versionedEntryBook.addListener(this::saveToStorageListener);
     }
 
     //=========== UserPrefs ==================================================================================
@@ -273,7 +273,7 @@ public class ModelManager implements Model {
     /**
      * Ensures that storage is updated whenever entry book is modified.
      */
-    private void ensureStorageSaved(Observable observable) {
+    private void saveToStorageListener(Observable observable) {
         logger.info("Address book modified, saving to file.");
         try {
             storage.saveAddressBook(versionedEntryBook);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -30,7 +30,7 @@ public class ModelManager implements Model {
 
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private final VersionedEntryBook versionedAddressBook;
+    private final VersionedEntryBook versionedEntryBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Entry> filteredEntries;
 
@@ -48,18 +48,18 @@ public class ModelManager implements Model {
 
         logger.fine("Initializing with address book: " + addressBook + " and user prefs " + userPrefs);
 
-        versionedAddressBook = new VersionedEntryBook(addressBook);
+        versionedEntryBook = new VersionedEntryBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
-        filteredEntries = new FilteredList<>(versionedAddressBook.getPersonList());
+        filteredEntries = new FilteredList<>(versionedEntryBook.getPersonList());
         filteredEntries.addListener(this::ensureSelectedPersonIsValid);
 
         this.storage = storage;
 
         // Save the models' address book to storage whenever it is modified.
-        versionedAddressBook.addListener(observable -> {
+        versionedEntryBook.addListener(observable -> {
             logger.info("Address book modified, saving to file.");
             try {
-                storage.saveAddressBook(versionedAddressBook);
+                storage.saveAddressBook(versionedEntryBook);
             } catch (IOException ioe) {
                 setException(new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe));
             }
@@ -105,28 +105,28 @@ public class ModelManager implements Model {
 
     @Override
     public void setAddressBook(ReadOnlyEntryBook addressBook) {
-        versionedAddressBook.resetData(addressBook);
+        versionedEntryBook.resetData(addressBook);
     }
 
     @Override
     public ReadOnlyEntryBook getAddressBook() {
-        return versionedAddressBook;
+        return versionedEntryBook;
     }
 
     @Override
     public boolean hasPerson(Entry entry) {
         requireNonNull(entry);
-        return versionedAddressBook.hasPerson(entry);
+        return versionedEntryBook.hasPerson(entry);
     }
 
     @Override
     public void deletePerson(Entry target) {
-        versionedAddressBook.removePerson(target);
+        versionedEntryBook.removePerson(target);
     }
 
     @Override
     public void addPerson(Entry entry) {
-        versionedAddressBook.addPerson(entry);
+        versionedEntryBook.addPerson(entry);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
@@ -134,12 +134,12 @@ public class ModelManager implements Model {
     public void setPerson(Entry target, Entry editedEntry) {
         requireAllNonNull(target, editedEntry);
 
-        versionedAddressBook.setPerson(target, editedEntry);
+        versionedEntryBook.setPerson(target, editedEntry);
     }
 
     @Override
     public void clearEntryBook() {
-        versionedAddressBook.clear();
+        versionedEntryBook.clear();
     }
 
     //=========== Storage ===================================================================================
@@ -153,7 +153,7 @@ public class ModelManager implements Model {
 
     /**
      * Returns an unmodifiable view of the list of {@code Entry} backed by the internal list of
-     * {@code versionedAddressBook}
+     * {@code versionedEntryBook}
      */
     @Override
     public ObservableList<Entry> getFilteredPersonList() {
@@ -170,27 +170,27 @@ public class ModelManager implements Model {
 
     @Override
     public boolean canUndoAddressBook() {
-        return versionedAddressBook.canUndo();
+        return versionedEntryBook.canUndo();
     }
 
     @Override
     public boolean canRedoAddressBook() {
-        return versionedAddressBook.canRedo();
+        return versionedEntryBook.canRedo();
     }
 
     @Override
     public void undoAddressBook() {
-        versionedAddressBook.undo();
+        versionedEntryBook.undo();
     }
 
     @Override
     public void redoAddressBook() {
-        versionedAddressBook.redo();
+        versionedEntryBook.redo();
     }
 
     @Override
     public void commitAddressBook() {
-        versionedAddressBook.commit();
+        versionedEntryBook.commit();
     }
 
     //=========== Selected entry ===========================================================================
@@ -290,7 +290,7 @@ public class ModelManager implements Model {
 
         // state check
         ModelManager other = (ModelManager) obj;
-        return versionedAddressBook.equals(other.versionedAddressBook)
+        return versionedEntryBook.equals(other.versionedEntryBook)
                 && userPrefs.equals(other.userPrefs)
                 && filteredEntries.equals(other.filteredEntries)
                 && Objects.equals(selectedPerson.get(), other.selectedPerson.get());
@@ -298,7 +298,7 @@ public class ModelManager implements Model {
 
     @Override
     public Model clone() {
-        return new ModelManager(this.versionedAddressBook, this.userPrefs, this.storage);
+        return new ModelManager(this.versionedEntryBook, this.userPrefs, this.storage);
     }
 
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
+import javafx.beans.Observable;
 import javafx.beans.property.ReadOnlyProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.ListChangeListener;
@@ -55,15 +56,8 @@ public class ModelManager implements Model {
 
         this.storage = storage;
 
-        // Save the models' address book to storage whenever it is modified.
-        versionedEntryBook.addListener(observable -> {
-            logger.info("Address book modified, saving to file.");
-            try {
-                storage.saveAddressBook(versionedEntryBook);
-            } catch (IOException ioe) {
-                setException(new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe));
-            }
-        });
+        // Save the entry book to storage whenever it is modified.
+        versionedEntryBook.addListener(this::ensureStorageSaved);
     }
 
     //=========== UserPrefs ==================================================================================
@@ -273,6 +267,18 @@ public class ModelManager implements Model {
                 // or clear the selection if there is no such entry.
                 selectedPerson.setValue(change.getFrom() > 0 ? change.getList().get(change.getFrom() - 1) : null);
             }
+        }
+    }
+
+    /**
+     * Ensures that storage is updated whenever entry book is modified.
+     */
+    private void ensureStorageSaved(Observable observable) {
+        logger.info("Address book modified, saving to file.");
+        try {
+            storage.saveAddressBook(versionedEntryBook);
+        } catch (IOException ioe) {
+            setException(new CommandException(FILE_OPS_ERROR_MESSAGE + ioe, ioe));
         }
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -195,24 +195,36 @@ public class ModelManager implements Model {
     //=========== Exception propagation ===========================================================================
 
     @Override
-    public ReadOnlyProperty<Exception> exceptionProperty() { return exception; }
+    public ReadOnlyProperty<Exception> exceptionProperty() {
+        return exception;
+    }
 
     @Override
-    public Exception getException() { return exception.getValue(); }
+    public Exception getException() {
+        return exception.getValue();
+    }
 
     @Override
-    public void setException(Exception exceptionToBePropagated) { exception.setValue(exceptionToBePropagated); }
+    public void setException(Exception exceptionToBePropagated) {
+        exception.setValue(exceptionToBePropagated);
+    }
 
     //=========== Command result ===========================================================================
 
     @Override
-    public ReadOnlyProperty<CommandResult> commandResultProperty() { return commandResult; }
+    public ReadOnlyProperty<CommandResult> commandResultProperty() {
+        return commandResult;
+    }
 
     @Override
-    public CommandResult getCommandResult() { return commandResult.getValue(); }
+    public CommandResult getCommandResult() {
+        return commandResult.getValue();
+    }
 
     @Override
-    public void setCommandResult(CommandResult result) { commandResult.setValue(result); }
+    public void setCommandResult(CommandResult result) {
+        commandResult.setValue(result);
+    }
 
     /**
      * Ensures {@code selectedPerson} is a valid entry in {@code filteredEntries}.

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -10,6 +10,7 @@ import seedu.address.commons.core.Config;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.exceptions.DataConversionException;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.mocks.StorageStub;
 import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -93,7 +94,7 @@ public class TestApp extends MainApp {
      * Returns a defensive copy of the model.
      */
     public Model getModel() {
-        Model copy = new ModelManager((model.getAddressBook()), new UserPrefs());
+        Model copy = new ModelManager((model.getAddressBook()), new UserPrefs(), new StorageStub());
         ModelHelper.setFilteredList(copy, model.getFilteredPersonList());
         return copy;
     }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -25,7 +25,7 @@ import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.mocks.StorageStub;
+import seedu.address.mocks.ModelManagerStub;
 import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -101,11 +101,7 @@ public class LogicManagerTest {
         String addCommand = AddCommand.COMMAND_WORD + TITLE_DESC_AMY + COMMENT_DESC_AMY + LINK_DESC_AMY
                 + ADDRESS_DESC_AMY;
         Entry expectedEntry = new EntryBuilder(AMY).withTags().build();
-        Model expectedModel = new ModelManager(
-                new EntryBook(),
-                new UserPrefs(),
-                new StorageStub()
-        );
+        Model expectedModel = new ModelManagerStub();
         expectedModel.addPerson(expectedEntry);
         expectedModel.commitAddressBook();
         String expectedInitialMessage = String.format(AddCommand.MESSAGE_SUCCESS, expectedEntry);

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -8,6 +8,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.StorageStub;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -24,14 +25,14 @@ public class AddCommandIntegrationTest {
 
     @Before
     public void setUp() {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
     }
 
     @Test
     public void execute_newPerson_success() {
         Entry validEntry = new EntryBuilder().build();
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new StorageStub());
         expectedModel.addPerson(validEntry);
         expectedModel.commitAddressBook();
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -2,16 +2,12 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.mocks.StorageStub;
+import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 import seedu.address.model.entry.Entry;
 import seedu.address.testutil.EntryBuilder;
 
@@ -20,19 +16,14 @@ import seedu.address.testutil.EntryBuilder;
  */
 public class AddCommandIntegrationTest {
 
-    private Model model;
+    private Model model = new TypicalModelManagerStub();
     private CommandHistory commandHistory = new CommandHistory();
-
-    @Before
-    public void setUp() {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
-    }
 
     @Test
     public void execute_newPerson_success() {
         Entry validEntry = new EntryBuilder().build();
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new StorageStub());
+        Model expectedModel = model.clone();
         expectedModel.addPerson(validEntry);
         expectedModel.commitAddressBook();
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -24,6 +24,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyEntryBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.entry.Entry;
+import seedu.address.storage.Storage;
 import seedu.address.testutil.EntryBuilder;
 
 public class AddCommandTest {
@@ -103,6 +104,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public Storage getStorage() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public GuiSettings getGuiSettings() {
             throw new AssertionError("This method should not be called.");
         }
@@ -149,6 +155,11 @@ public class AddCommandTest {
 
         @Override
         public void setPerson(Entry target, Entry editedEntry) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void clearEntryBook() {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -230,6 +241,11 @@ public class AddCommandTest {
         @Override
         public void setCommandResult(CommandResult result) {
             throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Model clone() {
+            return this;
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -6,6 +6,7 @@ import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.StorageStub;
 import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -17,8 +18,16 @@ public class ClearCommandTest {
 
     @Test
     public void execute_emptyAddressBook_success() {
-        Model model = new ModelManager();
-        Model expectedModel = new ModelManager();
+        Model model = new ModelManager(
+                new EntryBook(),
+                new UserPrefs(),
+                new StorageStub()
+        );
+        Model expectedModel = new ModelManager(
+                new EntryBook(),
+                new UserPrefs(),
+                new StorageStub()
+        );
         expectedModel.commitAddressBook();
 
         assertCommandSuccess(new ClearCommand(), model, commandHistory, ClearCommand.MESSAGE_SUCCESS, expectedModel);
@@ -26,8 +35,8 @@ public class ClearCommandTest {
 
     @Test
     public void execute_nonEmptyAddressBook_success() {
-        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
+        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
         expectedModel.setAddressBook(new EntryBook());
         expectedModel.commitAddressBook();
 

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -1,17 +1,14 @@
 package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.mocks.ModelManagerStub;
-import seedu.address.mocks.StorageStub;
+import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 
 public class ClearCommandTest {
 
@@ -28,8 +25,8 @@ public class ClearCommandTest {
 
     @Test
     public void execute_nonEmptyAddressBook_success() {
-        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
-        Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
+        Model model = new TypicalModelManagerStub();
+        Model expectedModel = new TypicalModelManagerStub();
         expectedModel.setAddressBook(new EntryBook());
         expectedModel.commitAddressBook();
 

--- a/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearCommandTest.java
@@ -6,6 +6,7 @@ import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.ModelManagerStub;
 import seedu.address.mocks.StorageStub;
 import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
@@ -18,16 +19,8 @@ public class ClearCommandTest {
 
     @Test
     public void execute_emptyAddressBook_success() {
-        Model model = new ModelManager(
-                new EntryBook(),
-                new UserPrefs(),
-                new StorageStub()
-        );
-        Model expectedModel = new ModelManager(
-                new EntryBook(),
-                new UserPrefs(),
-                new StorageStub()
-        );
+        Model model = new ModelManagerStub();
+        Model expectedModel = new ModelManagerStub();
         expectedModel.commitAddressBook();
 
         assertCommandSuccess(new ClearCommand(), model, commandHistory, ClearCommand.MESSAGE_SUCCESS, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.StorageStub;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -26,7 +27,7 @@ import seedu.address.model.entry.Entry;
  */
 public class DeleteCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test
@@ -36,7 +37,7 @@ public class DeleteCommandTest {
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, entryToDelete);
 
-        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new StorageStub());
         expectedModel.deletePerson(entryToDelete);
         expectedModel.commitAddressBook();
 
@@ -60,7 +61,7 @@ public class DeleteCommandTest {
 
         String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, entryToDelete);
 
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new StorageStub());
         expectedModel.deletePerson(entryToDelete);
         expectedModel.commitAddressBook();
         showNoPerson(expectedModel);
@@ -85,7 +86,7 @@ public class DeleteCommandTest {
     public void executeUndoRedo_validIndexUnfilteredList_success() throws Exception {
         Entry entryToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new StorageStub());
         expectedModel.deletePerson(entryToDelete);
         expectedModel.commitAddressBook();
 
@@ -124,7 +125,7 @@ public class DeleteCommandTest {
     @Test
     public void executeUndoRedo_validIndexFilteredList_samePersonDeleted() throws Exception {
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new StorageStub());
 
         showPersonAtIndex(model, INDEX_SECOND_PERSON);
         Entry entryToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
@@ -16,6 +15,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
 import seedu.address.mocks.StorageStub;
+import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -27,7 +27,7 @@ import seedu.address.model.entry.Entry;
  */
 public class DeleteCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
+    private Model model = new TypicalModelManagerStub();
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -11,7 +11,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 
@@ -21,10 +20,8 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.mocks.StorageStub;
+import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 import seedu.address.model.entry.Entry;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.EntryBuilder;
@@ -34,7 +31,7 @@ import seedu.address.testutil.EntryBuilder;
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
+    private Model model = new TypicalModelManagerStub();
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -21,7 +21,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.model.EntryBook;
+import seedu.address.mocks.StorageStub;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -34,7 +34,7 @@ import seedu.address.testutil.EntryBuilder;
  */
 public class EditCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test
@@ -45,7 +45,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedEntry);
 
-        Model expectedModel = new ModelManager(new EntryBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = model.clone();
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedEntry);
         expectedModel.commitAddressBook();
 
@@ -67,7 +67,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedEntry);
 
-        Model expectedModel = new ModelManager(new EntryBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = model.clone();
         expectedModel.setPerson(lastEntry, editedEntry);
         expectedModel.commitAddressBook();
 
@@ -81,7 +81,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedEntry);
 
-        Model expectedModel = new ModelManager(new EntryBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = model.clone();
         expectedModel.commitAddressBook();
 
         assertCommandSuccess(editCommand, model, commandHistory, expectedMessage, expectedModel);
@@ -98,7 +98,7 @@ public class EditCommandTest {
 
         String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedEntry);
 
-        Model expectedModel = new ModelManager(new EntryBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = model.clone();
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedEntry);
         expectedModel.commitAddressBook();
 
@@ -158,7 +158,7 @@ public class EditCommandTest {
         Entry entryToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedEntry).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
-        Model expectedModel = new ModelManager(new EntryBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = model.clone();
         expectedModel.setPerson(entryToEdit, editedEntry);
         expectedModel.commitAddressBook();
 
@@ -200,7 +200,7 @@ public class EditCommandTest {
         Entry editedEntry = new EntryBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedEntry).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
-        Model expectedModel = new ModelManager(new EntryBook(model.getAddressBook()), new UserPrefs());
+        Model expectedModel = model.clone();
 
         showPersonAtIndex(model, INDEX_SECOND_PERSON);
         Entry entryToEdit = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -6,23 +6,12 @@ import static seedu.address.logic.commands.ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEM
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.mocks.StorageStub;
-import seedu.address.model.EntryBook;
+import seedu.address.mocks.ModelManagerStub;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 
 public class ExitCommandTest {
-    private Model model = new ModelManager(
-            new EntryBook(),
-            new UserPrefs(),
-            new StorageStub()
-    );
-    private Model expectedModel = new ModelManager(
-            new EntryBook(),
-            new UserPrefs(),
-            new StorageStub()
-    );
+    private Model model = new ModelManagerStub();
+    private Model expectedModel = new ModelManagerStub();
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -6,12 +6,23 @@ import static seedu.address.logic.commands.ExitCommand.MESSAGE_EXIT_ACKNOWLEDGEM
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.StorageStub;
+import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 
 public class ExitCommandTest {
-    private Model model = new ModelManager();
-    private Model expectedModel = new ModelManager();
+    private Model model = new ModelManager(
+            new EntryBook(),
+            new UserPrefs(),
+            new StorageStub()
+    );
+    private Model expectedModel = new ModelManager(
+            new EntryBook(),
+            new UserPrefs(),
+            new StorageStub()
+    );
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -8,7 +8,6 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalEntries.CARL;
 import static seedu.address.testutil.TypicalEntries.ELLE;
 import static seedu.address.testutil.TypicalEntries.FIONA;
-import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,18 +15,16 @@ import java.util.Collections;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.mocks.StorageStub;
+import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 import seedu.address.model.entry.TitleContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
+    private Model model = new TypicalModelManagerStub();
+    private Model expectedModel = new TypicalModelManagerStub();
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.StorageStub;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -25,8 +26,8 @@ import seedu.address.model.entry.TitleContainsKeywordsPredicate;
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
  */
 public class FindCommandTest {
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -6,23 +6,12 @@ import static seedu.address.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.mocks.StorageStub;
-import seedu.address.model.EntryBook;
+import seedu.address.mocks.ModelManagerStub;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 
 public class HelpCommandTest {
-    private Model model = new ModelManager(
-            new EntryBook(),
-            new UserPrefs(),
-            new StorageStub()
-    );
-    private Model expectedModel = new ModelManager(
-            new EntryBook(),
-            new UserPrefs(),
-            new StorageStub()
-    );
+    private Model model = new ModelManagerStub();
+    private Model expectedModel = new ModelManagerStub();
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -6,12 +6,23 @@ import static seedu.address.logic.commands.HelpCommand.SHOWING_HELP_MESSAGE;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.StorageStub;
+import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 
 public class HelpCommandTest {
-    private Model model = new ModelManager();
-    private Model expectedModel = new ModelManager();
+    private Model model = new ModelManager(
+            new EntryBook(),
+            new UserPrefs(),
+            new StorageStub()
+    );
+    private Model expectedModel = new ModelManager(
+            new EntryBook(),
+            new UserPrefs(),
+            new StorageStub()
+    );
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/HistoryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HistoryCommandTest.java
@@ -5,13 +5,24 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.StorageStub;
+import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 
 public class HistoryCommandTest {
     private CommandHistory history = new CommandHistory();
-    private Model model = new ModelManager();
-    private Model expectedModel = new ModelManager();
+    private Model model = new ModelManager(
+            new EntryBook(),
+            new UserPrefs(),
+            new StorageStub()
+    );
+    private Model expectedModel = new ModelManager(
+            new EntryBook(),
+            new UserPrefs(),
+            new StorageStub()
+    );
 
     @Test
     public void execute() {

--- a/src/test/java/seedu/address/logic/commands/HistoryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HistoryCommandTest.java
@@ -5,24 +5,13 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.mocks.StorageStub;
-import seedu.address.model.EntryBook;
+import seedu.address.mocks.ModelManagerStub;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 
 public class HistoryCommandTest {
     private CommandHistory history = new CommandHistory();
-    private Model model = new ModelManager(
-            new EntryBook(),
-            new UserPrefs(),
-            new StorageStub()
-    );
-    private Model expectedModel = new ModelManager(
-            new EntryBook(),
-            new UserPrefs(),
-            new StorageStub()
-    );
+    private Model model = new ModelManagerStub();
+    private Model expectedModel = new ModelManagerStub();
 
     @Test
     public void execute() {

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -2,32 +2,22 @@ package seedu.address.logic.commands;
 
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.mocks.StorageStub;
+import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
  */
 public class ListCommandTest {
 
-    private Model model;
-    private Model expectedModel;
+    private Model model = new TypicalModelManagerStub();
+    private Model expectedModel = new TypicalModelManagerStub();
     private CommandHistory commandHistory = new CommandHistory();
-
-    @Before
-    public void setUp() {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
-        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new StorageStub());
-    }
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.StorageStub;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -24,8 +25,8 @@ public class ListCommandTest {
 
     @Before
     public void setUp() {
-        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs(), new StorageStub());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -9,14 +9,23 @@ import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.StorageStub;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 
 public class RedoCommandTest {
 
-    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model model = new ModelManager(
+            getTypicalAddressBook(),
+            new UserPrefs(),
+            new StorageStub()
+    );
+    private final Model expectedModel = new ModelManager(
+            getTypicalAddressBook(),
+            new UserPrefs(),
+            new StorageStub()
+    );
     private final CommandHistory commandHistory = new CommandHistory();
 
     @Before

--- a/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RedoCommandTest.java
@@ -3,29 +3,18 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.deleteFirstPerson;
-import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.mocks.StorageStub;
+import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 
 public class RedoCommandTest {
 
-    private final Model model = new ModelManager(
-            getTypicalAddressBook(),
-            new UserPrefs(),
-            new StorageStub()
-    );
-    private final Model expectedModel = new ModelManager(
-            getTypicalAddressBook(),
-            new UserPrefs(),
-            new StorageStub()
-    );
+    private final Model model = new TypicalModelManagerStub();
+    private final Model expectedModel = new TypicalModelManagerStub();
     private final CommandHistory commandHistory = new CommandHistory();
 
     @Before

--- a/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.StorageStub;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -23,8 +24,8 @@ import seedu.address.model.UserPrefs;
  * Contains integration tests (interaction with the Model) for {@code SelectCommand}.
  */
 public class SelectCommandTest {
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SelectCommandTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
-import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
@@ -15,17 +14,15 @@ import org.junit.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
-import seedu.address.mocks.StorageStub;
+import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code SelectCommand}.
  */
 public class SelectCommandTest {
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
+    private Model model = new TypicalModelManagerStub();
+    private Model expectedModel = new TypicalModelManagerStub();
     private CommandHistory commandHistory = new CommandHistory();
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -9,14 +9,15 @@ import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.StorageStub;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 
 public class UndoCommandTest {
 
-    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
+    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
     private final CommandHistory commandHistory = new CommandHistory();
 
     @Before

--- a/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UndoCommandTest.java
@@ -3,21 +3,18 @@ package seedu.address.logic.commands;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.CommandTestUtil.deleteFirstPerson;
-import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import seedu.address.logic.CommandHistory;
-import seedu.address.mocks.StorageStub;
+import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 
 public class UndoCommandTest {
 
-    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
-    private final Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
+    private final Model model = new TypicalModelManagerStub();
+    private final Model expectedModel = new TypicalModelManagerStub();
     private final CommandHistory commandHistory = new CommandHistory();
 
     @Before

--- a/src/test/java/seedu/address/mocks/ModelManagerStub.java
+++ b/src/test/java/seedu/address/mocks/ModelManagerStub.java
@@ -1,0 +1,16 @@
+package seedu.address.mocks;
+
+import seedu.address.model.EntryBook;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * A mock to create an empty ModelManager for testing purposes
+ */
+public class ModelManagerStub extends ModelManager {
+
+    public ModelManagerStub() {
+        super(new EntryBook(), new UserPrefs(), new StorageStub());
+    }
+
+}

--- a/src/test/java/seedu/address/mocks/StorageStub.java
+++ b/src/test/java/seedu/address/mocks/StorageStub.java
@@ -24,7 +24,9 @@ public class StorageStub implements Storage {
     }
 
     @Override
-    public void saveUserPrefs(ReadOnlyUserPrefs userPrefs) { }
+    public void saveUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        // Do nothing
+    }
 
     @Override
     public Path getAddressBookFilePath() {
@@ -42,9 +44,13 @@ public class StorageStub implements Storage {
     }
 
     @Override
-    public void saveAddressBook(ReadOnlyEntryBook addressBook) { }
+    public void saveAddressBook(ReadOnlyEntryBook addressBook) {
+        // Do nothing
+    }
 
     @Override
-    public void saveAddressBook(ReadOnlyEntryBook addressBook, Path filePath) { }
+    public void saveAddressBook(ReadOnlyEntryBook addressBook, Path filePath) {
+        // Do nothing
+    }
 
 }

--- a/src/test/java/seedu/address/mocks/StorageStub.java
+++ b/src/test/java/seedu/address/mocks/StorageStub.java
@@ -1,0 +1,50 @@
+package seedu.address.mocks;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+import seedu.address.model.ReadOnlyEntryBook;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.UserPrefs;
+import seedu.address.storage.Storage;
+
+/**
+ * A mock for Storage for ease of creating objects in tests
+ */
+public class StorageStub implements Storage {
+
+    @Override
+    public Path getUserPrefsFilePath() {
+        return null;
+    }
+
+    @Override
+    public Optional<UserPrefs> readUserPrefs() {
+        return Optional.empty();
+    }
+
+    @Override
+    public void saveUserPrefs(ReadOnlyUserPrefs userPrefs) { }
+
+    @Override
+    public Path getAddressBookFilePath() {
+        return null;
+    }
+
+    @Override
+    public Optional<ReadOnlyEntryBook> readAddressBook() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ReadOnlyEntryBook> readAddressBook(Path filePath) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void saveAddressBook(ReadOnlyEntryBook addressBook) { }
+
+    @Override
+    public void saveAddressBook(ReadOnlyEntryBook addressBook, Path filePath) { }
+
+}

--- a/src/test/java/seedu/address/mocks/TypicalModelManagerStub.java
+++ b/src/test/java/seedu/address/mocks/TypicalModelManagerStub.java
@@ -1,0 +1,17 @@
+package seedu.address.mocks;
+
+import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
+
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+/**
+ * A mock to create a ModelManager initialised with typical entries.
+ */
+public class TypicalModelManagerStub extends ModelManager {
+
+    public TypicalModelManagerStub() {
+        super(getTypicalAddressBook(), new UserPrefs(), new StorageStub());
+    }
+
+}

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -19,9 +19,11 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.mocks.StorageStub;
 import seedu.address.model.entry.Entry;
 import seedu.address.model.entry.TitleContainsKeywordsPredicate;
 import seedu.address.model.entry.exceptions.EntryNotFoundException;
+import seedu.address.storage.Storage;
 import seedu.address.testutil.EntryBookBuilder;
 import seedu.address.testutil.EntryBuilder;
 
@@ -29,7 +31,11 @@ public class ModelManagerTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private ModelManager modelManager = new ModelManager();
+    private ModelManager modelManager = new ModelManager(
+            new EntryBook(),
+            new UserPrefs(),
+            new StorageStub()
+    );
 
     @Test
     public void constructor() {
@@ -154,10 +160,11 @@ public class ModelManagerTest {
         EntryBook addressBook = new EntryBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
         EntryBook differentAddressBook = new EntryBook();
         UserPrefs userPrefs = new UserPrefs();
+        Storage storage = new StorageStub();
 
         // same values -> returns true
-        modelManager = new ModelManager(addressBook, userPrefs);
-        ModelManager modelManagerCopy = new ModelManager(addressBook, userPrefs);
+        modelManager = new ModelManager(addressBook, userPrefs, storage);
+        ModelManager modelManagerCopy = new ModelManager(addressBook, userPrefs, storage);
         assertTrue(modelManager.equals(modelManagerCopy));
 
         // same object -> returns true
@@ -170,12 +177,12 @@ public class ModelManagerTest {
         assertFalse(modelManager.equals(5));
 
         // different addressBook -> returns false
-        assertFalse(modelManager.equals(new ModelManager(differentAddressBook, userPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(differentAddressBook, userPrefs, storage)));
 
         // different filteredList -> returns false
         String[] keywords = ALICE.getTitle().fullTitle.split("\\s+");
         modelManager.updateFilteredPersonList(new TitleContainsKeywordsPredicate(Arrays.asList(keywords)));
-        assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs, storage)));
 
         // resets modelManager to initial state for upcoming tests
         modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
@@ -183,6 +190,6 @@ public class ModelManagerTest {
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setAddressBookFilePath(Paths.get("differentFilePath"));
-        assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs)));
+        assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs, storage)));
     }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.mocks.ModelManagerStub;
 import seedu.address.mocks.StorageStub;
 import seedu.address.model.entry.Entry;
 import seedu.address.model.entry.TitleContainsKeywordsPredicate;
@@ -31,11 +32,7 @@ public class ModelManagerTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private ModelManager modelManager = new ModelManager(
-            new EntryBook(),
-            new UserPrefs(),
-            new StorageStub()
-    );
+    private ModelManager modelManager = new ModelManagerStub();
 
     @Test
     public void constructor() {

--- a/src/test/java/seedu/address/network/NetworkTest.java
+++ b/src/test/java/seedu/address/network/NetworkTest.java
@@ -9,6 +9,7 @@ import static seedu.address.network.Network.fetchAsString;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,20 +22,23 @@ public class NetworkTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
+    private String localTestContents = "<!DOCTYPE html>\n<html>\n</html>\n";
+
     @Test
     public void fetchAsStream_success() throws IOException {
-        InputStream httpsContent = fetchAsStream("https://se-education.org/");
-        assertTrue(httpsContent.readAllBytes().length > 0);
+        InputStream httpsContent = fetchAsStream("https://cs2103-ay1819s2-w10-1.github.io/main/networktests/");
+        byte[] httpsContentBytes = httpsContent.readAllBytes();
+        assertTrue(httpsContentBytes.length > 0);
+        assertTrue(new String(httpsContentBytes, StandardCharsets.UTF_8).contains("<p>It works!</p>"));
 
-        InputStream httpContent = fetchAsStream("http://se-education.org/");
+        InputStream httpContent = fetchAsStream("http://cs2103-ay1819s2-w10-1.github.io/main/networktests/");
         assertTrue(httpContent.readAllBytes().length > 0);
 
         InputStream localContent = fetchAsStream(MainApp.class.getResource(
                 "/view/NetworkTest/default.html").toExternalForm());
         byte[] localContentBytes = localContent.readAllBytes();
         assertTrue(localContentBytes.length > 0);
-
-        assertArrayEquals(localContentBytes, "<!DOCTYPE html>\n<html>\n</html>\n".getBytes());
+        assertArrayEquals(localContentBytes, localTestContents.getBytes());
     }
 
     @Test
@@ -52,17 +56,18 @@ public class NetworkTest {
     @Test
     public void fetchAsString_success() {
         try {
-            String httpsContent = fetchAsString("https://se-education.org/");
+            String httpsContent = fetchAsString("https://cs2103-ay1819s2-w10-1.github.io/main/networktests/");
             assertTrue(httpsContent.length() > 0);
+            assertTrue(httpsContent.contains("<p>It works!</p>"));
 
-            String httpContent = fetchAsString("http://se-education.org/");
+            String httpContent = fetchAsString("http://cs2103-ay1819s2-w10-1.github.io/main/networktests/");
             assertTrue(httpContent.length() > 0);
 
             String localContent = fetchAsString(
                     MainApp.class.getResource("/view/NetworkTest/default.html").toExternalForm());
             assertTrue(localContent.length() > 0);
 
-            assertEquals(localContent, "<!DOCTYPE html>\n<html>\n</html>\n");
+            assertEquals(localContent, localTestContents);
         } catch (IOException e) {
             fail("Fetching valid URL failed.");
         }

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -5,15 +5,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.rules.TemporaryFolder;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.entry.Entry;
-import seedu.address.storage.JsonEntryBookStorage;
-import seedu.address.storage.JsonUserPrefsStorage;
-import seedu.address.storage.Storage;
-import seedu.address.storage.StorageManager;
 
 /**
  * A utility class for test cases.
@@ -57,15 +51,5 @@ public class TestUtil {
      */
     public static Entry getPerson(Model model, Index index) {
         return model.getFilteredPersonList().get(index.getZeroBased());
-    }
-
-    /**
-     * Creates a temporary Storage
-     */
-    public static Storage makeTempStorage() throws IOException {
-        TemporaryFolder temporaryFolder = new TemporaryFolder();
-        JsonEntryBookStorage addressBookStorage = new JsonEntryBookStorage(temporaryFolder.newFile().toPath());
-        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.newFile().toPath());
-        return new StorageManager(addressBookStorage, userPrefsStorage);
     }
 }

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -5,9 +5,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.junit.rules.TemporaryFolder;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.entry.Entry;
+import seedu.address.storage.JsonEntryBookStorage;
+import seedu.address.storage.JsonUserPrefsStorage;
+import seedu.address.storage.Storage;
+import seedu.address.storage.StorageManager;
 
 /**
  * A utility class for test cases.
@@ -51,5 +57,15 @@ public class TestUtil {
      */
     public static Entry getPerson(Model model, Index index) {
         return model.getFilteredPersonList().get(index.getZeroBased());
+    }
+
+    /**
+     * Creates a temporary Storage
+     */
+    public static Storage makeTempStorage() throws IOException {
+        TemporaryFolder temporaryFolder = new TemporaryFolder();
+        JsonEntryBookStorage addressBookStorage = new JsonEntryBookStorage(temporaryFolder.newFile().toPath());
+        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.newFile().toPath());
+        return new StorageManager(addressBookStorage, userPrefsStorage);
     }
 }

--- a/src/test/java/seedu/address/ui/MainWindowCloseTest.java
+++ b/src/test/java/seedu/address/ui/MainWindowCloseTest.java
@@ -6,9 +6,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Collections;
 
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import org.testfx.api.FxToolkit;
 
 import guitests.guihandles.HelpWindowHandle;
@@ -16,33 +14,21 @@ import guitests.guihandles.StageHandle;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 import seedu.address.logic.LogicManager;
-import seedu.address.model.EntryBook;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
-import seedu.address.storage.JsonEntryBookStorage;
-import seedu.address.storage.JsonUserPrefsStorage;
-import seedu.address.storage.StorageManager;
+import seedu.address.mocks.ModelManagerStub;
 
 /**
  * Contains tests for closing of the {@code MainWindow}.
  */
 public class MainWindowCloseTest extends GuiUnitTest {
-    @Rule
-    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-
     private MainWindow mainWindow;
     private EmptyMainWindowHandle mainWindowHandle;
     private Stage stage;
 
     @Before
     public void setUp() throws Exception {
-        JsonEntryBookStorage jsonAddressBookStorage = new JsonEntryBookStorage(temporaryFolder.newFile().toPath());
-        JsonUserPrefsStorage jsonUserPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.newFile().toPath());
-        StorageManager storageManager = new StorageManager(jsonAddressBookStorage, jsonUserPrefsStorage);
         FxToolkit.setupStage(stage -> {
             this.stage = stage;
-            mainWindow = new MainWindow(stage, new LogicManager(
-                    new ModelManager(new EntryBook(), new UserPrefs(), storageManager)));
+            mainWindow = new MainWindow(stage, new LogicManager(new ModelManagerStub()));
             mainWindowHandle = new EmptyMainWindowHandle(stage);
             mainWindowHandle.focus();
         });

--- a/src/test/java/seedu/address/ui/MainWindowCloseTest.java
+++ b/src/test/java/seedu/address/ui/MainWindowCloseTest.java
@@ -16,7 +16,9 @@ import guitests.guihandles.StageHandle;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 import seedu.address.logic.LogicManager;
+import seedu.address.model.EntryBook;
 import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 import seedu.address.storage.JsonEntryBookStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.StorageManager;
@@ -39,7 +41,8 @@ public class MainWindowCloseTest extends GuiUnitTest {
         StorageManager storageManager = new StorageManager(jsonAddressBookStorage, jsonUserPrefsStorage);
         FxToolkit.setupStage(stage -> {
             this.stage = stage;
-            mainWindow = new MainWindow(stage, new LogicManager(new ModelManager(), storageManager));
+            mainWindow = new MainWindow(stage, new LogicManager(
+                    new ModelManager(new EntryBook(), new UserPrefs(), storageManager)));
             mainWindowHandle = new EmptyMainWindowHandle(stage);
             mainWindowHandle.focus();
         });

--- a/src/test/java/systemtests/ClearCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearCommandSystemTest.java
@@ -9,11 +9,8 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
-import seedu.address.mocks.StorageStub;
-import seedu.address.model.EntryBook;
+import seedu.address.mocks.ModelManagerStub;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
 
 public class ClearCommandSystemTest extends AddressBookSystemTest {
 
@@ -36,14 +33,7 @@ public class ClearCommandSystemTest extends AddressBookSystemTest {
         /* Case: redo clearing address book -> cleared */
         command = RedoCommand.COMMAND_WORD;
         expectedResultMessage = RedoCommand.MESSAGE_SUCCESS;
-        assertCommandSuccess(
-                command,
-                expectedResultMessage,
-                new ModelManager(
-                        new EntryBook(),
-                        new UserPrefs(),
-                        new StorageStub()
-                ));
+        assertCommandSuccess(command, expectedResultMessage, new ModelManagerStub());
         assertSelectedCardUnchanged();
 
         /* Case: selects first card in entry list and clears address book -> cleared and no card selected */
@@ -75,14 +65,7 @@ public class ClearCommandSystemTest extends AddressBookSystemTest {
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
      */
     private void assertCommandSuccess(String command) {
-        assertCommandSuccess(
-                command,
-                ClearCommand.MESSAGE_SUCCESS,
-                new ModelManager(
-                        new EntryBook(),
-                        new UserPrefs(),
-                        new StorageStub()
-                ));
+        assertCommandSuccess(command, ClearCommand.MESSAGE_SUCCESS, new ModelManagerStub());
     }
 
     /**

--- a/src/test/java/systemtests/ClearCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearCommandSystemTest.java
@@ -9,8 +9,11 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.mocks.StorageStub;
+import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 
 public class ClearCommandSystemTest extends AddressBookSystemTest {
 
@@ -33,7 +36,14 @@ public class ClearCommandSystemTest extends AddressBookSystemTest {
         /* Case: redo clearing address book -> cleared */
         command = RedoCommand.COMMAND_WORD;
         expectedResultMessage = RedoCommand.MESSAGE_SUCCESS;
-        assertCommandSuccess(command, expectedResultMessage, new ModelManager());
+        assertCommandSuccess(
+                command,
+                expectedResultMessage,
+                new ModelManager(
+                        new EntryBook(),
+                        new UserPrefs(),
+                        new StorageStub()
+                ));
         assertSelectedCardUnchanged();
 
         /* Case: selects first card in entry list and clears address book -> cleared and no card selected */
@@ -65,7 +75,14 @@ public class ClearCommandSystemTest extends AddressBookSystemTest {
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
      */
     private void assertCommandSuccess(String command) {
-        assertCommandSuccess(command, ClearCommand.MESSAGE_SUCCESS, new ModelManager());
+        assertCommandSuccess(
+                command,
+                ClearCommand.MESSAGE_SUCCESS,
+                new ModelManager(
+                        new EntryBook(),
+                        new UserPrefs(),
+                        new StorageStub()
+                ));
     }
 
     /**


### PR DESCRIPTION
Part of #22. We need to expose Storage to Model so that pages can be saved.

This is because we want to use the filesystem state as the canonical
representation sometimes, i.e. for article storage, which we don't want
to store in memory as the articles can be quite large.

We could simply expose the Storage to the Model as well, but doing so
results in Storage being referenced both from the outside at Logic,
and also from the inside whenever articles have to be added.

Instead we move the entire Storage behind Model for a cleaner
architecture -- now Storage should be an "implementation detail"
that the Model uses to persist itself.