### PR TITLE
Make add command save webpages to disk

### DIFF
--- a/src/main/java/seedu/address/MainApp.java
+++ b/src/main/java/seedu/address/MainApp.java
@@ -22,6 +22,8 @@ import seedu.address.model.ReadOnlyEntryBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.util.SampleDataUtil;
+import seedu.address.storage.ArticleStorage;
+import seedu.address.storage.DataDirectoryArticleStorage;
 import seedu.address.storage.EntryBookStorage;
 import seedu.address.storage.JsonEntryBookStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
@@ -57,7 +59,8 @@ public class MainApp extends Application {
         UserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(config.getUserPrefsFilePath());
         UserPrefs userPrefs = initPrefs(userPrefsStorage);
         EntryBookStorage entryBookStorage = new JsonEntryBookStorage(userPrefs.getAddressBookFilePath());
-        storage = new StorageManager(entryBookStorage, userPrefsStorage);
+        ArticleStorage articleStorage = new DataDirectoryArticleStorage(userPrefs.getArticleDataDirectoryPath());
+        storage = new StorageManager(entryBookStorage, userPrefsStorage, articleStorage);
 
         initLogging(config);
 

--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -55,6 +55,13 @@ public class FileUtil {
     }
 
     /**
+     * Creates a directory if it does not exist along with its missing parent directories.
+     */
+    public static void createDirectory(Path directory) throws IOException {
+        Files.createDirectories(directory);
+    }
+
+    /**
      * Creates parent directories of file if it has a parent directory
      */
     public static void createParentDirsOfFile(Path file) throws IOException {
@@ -78,6 +85,14 @@ public class FileUtil {
      */
     public static void writeToFile(Path file, String content) throws IOException {
         Files.write(file, content.getBytes(CHARSET));
+    }
+
+    /**
+     * Writes given bytes to a file.
+     * Will create the file if it does not exist yet.
+     */
+    public static void writeToFile(Path file, byte[] content) throws IOException {
+        Files.write(file, content);
     }
 
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -53,6 +53,15 @@ public interface Model {
     void setAddressBookFilePath(Path addressBookFilePath);
 
     /**
+     * Returns the user prefs' article data directory path.
+     */
+    Path getArticleDataDirectoryPath();
+
+    /**
+     * Sets the user prefs' article data directory path.
+     */
+    void setArticleDataDirectoryPath(Path articleDataDirectoryPath);
+    /**
      * Replaces address book data with the data in {@code addressBook}.
      */
     void setAddressBook(ReadOnlyEntryBook addressBook);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.entry.Entry;
 import seedu.address.model.entry.exceptions.EntryNotFoundException;
+import seedu.address.network.Network;
 import seedu.address.storage.Storage;
 
 /**
@@ -121,6 +122,12 @@ public class ModelManager implements Model {
     @Override
     public void addPerson(Entry entry) {
         versionedEntryBook.addPerson(entry);
+        try {
+            byte[] articleContent = Network.fetchAsBytes(entry.getLink().value);
+            storage.addArticle(entry.getLink().value, articleContent);
+        } catch (IOException ioe) {
+            // Do nothing if we fail to fetch the page.
+        }
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -96,6 +96,18 @@ public class ModelManager implements Model {
         userPrefs.setAddressBookFilePath(addressBookFilePath);
     }
 
+    @Override
+    public Path getArticleDataDirectoryPath() {
+        return userPrefs.getArticleDataDirectoryPath();
+    }
+
+    @Override
+    public void setArticleDataDirectoryPath(Path articleDataDirectoryPath) {
+        requireNonNull(articleDataDirectoryPath);
+        userPrefs.setArticleDataDirectoryPath(articleDataDirectoryPath);
+    }
+
+
     //=========== EntryBook ================================================================================
 
     @Override

--- a/src/main/java/seedu/address/model/ReadOnlyUserPrefs.java
+++ b/src/main/java/seedu/address/model/ReadOnlyUserPrefs.java
@@ -13,4 +13,6 @@ public interface ReadOnlyUserPrefs {
 
     Path getAddressBookFilePath();
 
+    Path getArticleDataDirectoryPath();
+
 }

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -15,6 +15,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
     private Path addressBookFilePath = Paths.get("data" , "entrybook.json");
+    private Path articleDataDirectoryPath = Paths.get("data", "articles");
 
     /**
      * Creates a {@code UserPrefs} with default values.
@@ -54,6 +55,15 @@ public class UserPrefs implements ReadOnlyUserPrefs {
     public void setAddressBookFilePath(Path addressBookFilePath) {
         requireNonNull(addressBookFilePath);
         this.addressBookFilePath = addressBookFilePath;
+    }
+
+    public Path getArticleDataDirectoryPath() {
+        return articleDataDirectoryPath;
+    }
+
+    public void setArticleDataDirectoryPath(Path articleDataDirectoryPath) {
+        requireNonNull(articleDataDirectoryPath);
+        this.articleDataDirectoryPath = articleDataDirectoryPath;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -37,6 +37,7 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         requireNonNull(newUserPrefs);
         setGuiSettings(newUserPrefs.getGuiSettings());
         setAddressBookFilePath(newUserPrefs.getAddressBookFilePath());
+        setArticleDataDirectoryPath(newUserPrefs.getArticleDataDirectoryPath());
     }
 
     public GuiSettings getGuiSettings() {
@@ -78,7 +79,8 @@ public class UserPrefs implements ReadOnlyUserPrefs {
         UserPrefs o = (UserPrefs) other;
 
         return guiSettings.equals(o.guiSettings)
-                && addressBookFilePath.equals(o.addressBookFilePath);
+                && addressBookFilePath.equals(o.addressBookFilePath)
+                && articleDataDirectoryPath.equals(o.articleDataDirectoryPath);
     }
 
     @Override

--- a/src/main/java/seedu/address/network/Network.java
+++ b/src/main/java/seedu/address/network/Network.java
@@ -27,4 +27,14 @@ public abstract class Network {
     public static String fetchAsString(String url) throws IOException {
         return new String(new URL(url).openStream().readAllBytes(), "utf-8");
     }
+
+    /**
+     * Fetches the resource (i.e. webpage) at url, returning it as a byte array
+     * @param url
+     * @return The content fetched.
+     * @throws IOException
+     */
+    public static byte[] fetchAsBytes(String url) throws IOException {
+        return new URL(url).openStream().readAllBytes();
+    }
 }

--- a/src/main/java/seedu/address/storage/ArticleStorage.java
+++ b/src/main/java/seedu/address/storage/ArticleStorage.java
@@ -1,0 +1,28 @@
+package seedu.address.storage;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Represents a storage for articles.
+ */
+public interface ArticleStorage {
+
+    /**
+     * Returns the data directory path where articles are stored.
+     */
+    Path getArticleDataDirectoryPath();
+
+    /**
+     * Saves the given article to the storage.
+     * @param articleContent cannot be null.
+     * @param url cannot be null.
+     * @throws IOException if there was any problem writing to the file.
+     */
+    void addArticle(String url, byte[] articleContent) throws IOException;
+
+    /**
+     * Converts a given url to a Path where the article would be stored.
+     */
+    Path getArticlePath(String url);
+}

--- a/src/main/java/seedu/address/storage/DataDirectoryArticleStorage.java
+++ b/src/main/java/seedu/address/storage/DataDirectoryArticleStorage.java
@@ -1,0 +1,70 @@
+package seedu.address.storage;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.logging.Logger;
+
+import org.apache.commons.codec.binary.Base32;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.util.FileUtil;
+
+/**
+ * A class to access UserPrefs stored in the hard disk as a json file
+ */
+public class DataDirectoryArticleStorage implements ArticleStorage {
+
+    private Path directoryPath;
+    private Logger logger = LogsCenter.getLogger(DataDirectoryArticleStorage.class);
+
+    public DataDirectoryArticleStorage(Path directoryPath) {
+        this.directoryPath = directoryPath;
+    }
+
+    @Override
+    public Path getArticleDataDirectoryPath() {
+        return directoryPath;
+    }
+
+    @Override
+    public void addArticle(String url, byte[] articleContent) throws IOException {
+        Path targetPath = getArticlePath(url);
+
+        // Ensure data directory exists
+        FileUtil.createDirectory(directoryPath);
+
+        FileUtil.writeToFile(targetPath, articleContent);
+    }
+
+    /**
+     * Converts the given url to a filename that will be used to write to.
+     */
+    private String urlToFilename(String url) throws NoSuchAlgorithmException {
+        String lowercaseUrl = url.toLowerCase();
+
+        try {
+            // We hash the URL with sha-256, truncate it to 128 bits so it's shorter, then encode it in base32
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] encodedHash = digest.digest(lowercaseUrl.getBytes(StandardCharsets.UTF_8));
+            byte[] truncatedHash = new byte[16];
+            System.arraycopy(encodedHash, 0, truncatedHash, 0, 16);
+            byte[] hashInBase32 = new Base32().encode(truncatedHash);
+            return new String(hashInBase32, StandardCharsets.UTF_8);
+        } catch (NoSuchAlgorithmException nsae) {
+            logger.severe("SHA-256 hash not supported on this system. Saving links cannot be done");
+            throw nsae;
+        }
+    }
+
+    public Path getArticlePath(String url) {
+        try {
+            return directoryPath.resolve(urlToFilename(url));
+        } catch (NoSuchAlgorithmException nsae) {
+            throw new RuntimeException(nsae);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -12,7 +12,7 @@ import seedu.address.model.UserPrefs;
 /**
  * API of the Storage component
  */
-public interface Storage extends EntryBookStorage, UserPrefsStorage {
+public interface Storage extends EntryBookStorage, UserPrefsStorage, ArticleStorage {
 
     @Override
     Optional<UserPrefs> readUserPrefs() throws DataConversionException, IOException;
@@ -28,5 +28,8 @@ public interface Storage extends EntryBookStorage, UserPrefsStorage {
 
     @Override
     void saveAddressBook(ReadOnlyEntryBook addressBook) throws IOException;
+
+    @Override
+    void addArticle(String url, byte[] articleContent) throws IOException;
 
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -19,12 +19,17 @@ public class StorageManager implements Storage {
     private static final Logger logger = LogsCenter.getLogger(StorageManager.class);
     private EntryBookStorage entryBookStorage;
     private UserPrefsStorage userPrefsStorage;
+    private ArticleStorage articleStorage;
 
 
-    public StorageManager(EntryBookStorage entryBookStorage, UserPrefsStorage userPrefsStorage) {
+    public StorageManager(
+            EntryBookStorage entryBookStorage,
+            UserPrefsStorage userPrefsStorage,
+            ArticleStorage articleStorage) {
         super();
         this.entryBookStorage = entryBookStorage;
         this.userPrefsStorage = userPrefsStorage;
+        this.articleStorage = articleStorage;
     }
 
     // ================ UserPrefs methods ==============================
@@ -74,4 +79,20 @@ public class StorageManager implements Storage {
         entryBookStorage.saveAddressBook(addressBook, filePath);
     }
 
+    // ================ article methods ================================
+
+    @Override
+    public Path getArticleDataDirectoryPath() {
+        return articleStorage.getArticleDataDirectoryPath();
+    }
+
+    @Override
+    public void addArticle(String url, byte[] content) throws IOException {
+        articleStorage.addArticle(url, content);
+    }
+
+    @Override
+    public Path getArticlePath(String url) {
+        return articleStorage.getArticlePath(url);
+    }
 }

--- a/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
@@ -9,5 +9,6 @@
       "z" : 99
     }
   },
-  "addressBookFilePath" : "addressbook.json"
+  "addressBookFilePath" : "addressbook.json",
+  "articleDataDirectoryPath" : "data"
 }

--- a/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
@@ -7,5 +7,6 @@
       "y" : 100
     }
   },
-  "addressBookFilePath" : "addressbook.json"
+  "addressBookFilePath" : "addressbook.json",
+  "articleDataDirectoryPath" : "data"
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -32,6 +32,8 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyEntryBook;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.entry.Entry;
+import seedu.address.storage.ArticleStorage;
+import seedu.address.storage.DataDirectoryArticleStorage;
 import seedu.address.storage.JsonEntryBookStorage;
 import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.StorageManager;
@@ -54,7 +56,8 @@ public class LogicManagerTest {
     public void setUp() throws Exception {
         JsonEntryBookStorage addressBookStorage = new JsonEntryBookStorage(temporaryFolder.newFile().toPath());
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.newFile().toPath());
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        ArticleStorage articleStorage = new DataDirectoryArticleStorage(temporaryFolder.newFolder().toPath());
+        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage, articleStorage);
         model = new ModelManager(new EntryBook(), new UserPrefs(), storage);
         logic = new LogicManager(model);
     }
@@ -93,7 +96,8 @@ public class LogicManagerTest {
         JsonEntryBookStorage addressBookStorage =
                 new JsonEntryBookIoExceptionThrowingStub(temporaryFolder.newFile().toPath());
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.newFile().toPath());
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
+        ArticleStorage articleStorage = new DataDirectoryArticleStorage(temporaryFolder.newFolder().toPath());
+        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage, articleStorage);
         model = new ModelManager(model.getAddressBook(), model.getUserPrefs(), storage);
         logic = new LogicManager(model);
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -129,6 +129,16 @@ public class AddCommandTest {
         }
 
         @Override
+        public Path getArticleDataDirectoryPath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setArticleDataDirectoryPath(Path articleDataDirectoryPath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void addPerson(Entry entry) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/mocks/StorageStub.java
+++ b/src/test/java/seedu/address/mocks/StorageStub.java
@@ -53,4 +53,18 @@ public class StorageStub implements Storage {
         // Do nothing
     }
 
+    @Override
+    public Path getArticleDataDirectoryPath() {
+        return null;
+    }
+
+    @Override
+    public void addArticle(String url, byte[] content) {
+        // Do nothing
+    }
+
+    @Override
+    public Path getArticlePath(String url) {
+        return null;
+    }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -67,6 +67,7 @@ public class ModelManagerTest {
     public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setAddressBookFilePath(Paths.get("address/book/file/path"));
+        userPrefs.setArticleDataDirectoryPath(Paths.get("article/data/directory/path"));
         userPrefs.setGuiSettings(new GuiSettings(1, 2, 3, 4));
         modelManager.setUserPrefs(userPrefs);
         assertEquals(userPrefs, modelManager.getUserPrefs());
@@ -74,6 +75,7 @@ public class ModelManagerTest {
         // Modifying userPrefs should not modify modelManager's userPrefs
         UserPrefs oldUserPrefs = new UserPrefs(userPrefs);
         userPrefs.setAddressBookFilePath(Paths.get("new/address/book/file/path"));
+        userPrefs.setArticleDataDirectoryPath(Paths.get("new/article/data/directory/path"));
         assertEquals(oldUserPrefs, modelManager.getUserPrefs());
     }
 
@@ -101,6 +103,19 @@ public class ModelManagerTest {
         Path path = Paths.get("address/book/file/path");
         modelManager.setAddressBookFilePath(path);
         assertEquals(path, modelManager.getAddressBookFilePath());
+    }
+
+    @Test
+    public void setArticleDataDirectoryPath_nullPath_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        modelManager.setArticleDataDirectoryPath(null);
+    }
+
+    @Test
+    public void setArticleDataDirectoryPath_validPath_setsAddressBookFilePath() {
+        Path path = Paths.get("article/data/directory/path");
+        modelManager.setArticleDataDirectoryPath(path);
+        assertEquals(path, modelManager.getArticleDataDirectoryPath());
     }
 
     @Test
@@ -202,6 +217,10 @@ public class ModelManagerTest {
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setAddressBookFilePath(Paths.get("differentFilePath"));
+        assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs, storage)));
+
+        UserPrefs differentUserPrefs2 = new UserPrefs();
+        differentUserPrefs2.setArticleDataDirectoryPath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs, storage)));
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -8,7 +8,13 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.TypicalEntries.ALICE;
 import static seedu.address.testutil.TypicalEntries.BENSON;
 import static seedu.address.testutil.TypicalEntries.BOB;
+import static seedu.address.testutil.TypicalEntries.FILE_TEST_CONTENTS;
+import static seedu.address.testutil.TypicalEntries.VALID_FILE_LINK;
+import static seedu.address.testutil.TypicalEntries.VALID_HTTPS_LINK;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -17,6 +23,7 @@ import java.util.Collections;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.mocks.ModelManagerStub;
@@ -24,13 +31,21 @@ import seedu.address.mocks.StorageStub;
 import seedu.address.model.entry.Entry;
 import seedu.address.model.entry.TitleContainsKeywordsPredicate;
 import seedu.address.model.entry.exceptions.EntryNotFoundException;
+import seedu.address.storage.ArticleStorage;
+import seedu.address.storage.DataDirectoryArticleStorage;
+import seedu.address.storage.JsonEntryBookStorage;
+import seedu.address.storage.JsonUserPrefsStorage;
 import seedu.address.storage.Storage;
+import seedu.address.storage.StorageManager;
 import seedu.address.testutil.EntryBookBuilder;
 import seedu.address.testutil.EntryBuilder;
 
 public class ModelManagerTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
 
     private ModelManager modelManager = new ModelManagerStub();
 
@@ -188,5 +203,49 @@ public class ModelManagerTest {
         UserPrefs differentUserPrefs = new UserPrefs();
         differentUserPrefs.setAddressBookFilePath(Paths.get("differentFilePath"));
         assertFalse(modelManager.equals(new ModelManager(addressBook, differentUserPrefs, storage)));
+    }
+
+    /**
+     * This is an integration test to see that ModelManager#addPerson is properly hooked up to ArticleStorage.
+     */
+    @Test
+    public void addPerson_networkArticleSavedToDisk() throws IOException {
+        JsonEntryBookStorage addressBookStorage = new JsonEntryBookStorage(getTempFilePath("ab"));
+        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
+        ArticleStorage articleStorage = new DataDirectoryArticleStorage(getTempFilePath("articles"));
+        Storage storageManager = new StorageManager(addressBookStorage, userPrefsStorage, articleStorage);
+        modelManager = new ModelManager(new EntryBook(), new UserPrefs(), storageManager);
+        modelManager.addPerson(VALID_HTTPS_LINK);
+        String content = new String(
+                Files.readAllBytes(
+                        modelManager
+                                .getStorage()
+                                .getArticlePath(VALID_HTTPS_LINK.getLink().value)),
+                StandardCharsets.UTF_8);
+        assertTrue(content.contains("<p>It works!</p>"));
+    }
+
+    /**
+     * This is an integration test to see that ModelManager#addPerson is properly hooked up to ArticleStorage.
+     */
+    @Test
+    public void addPerson_localArticleSavedToDisk() throws IOException {
+        JsonEntryBookStorage addressBookStorage = new JsonEntryBookStorage(getTempFilePath("ab"));
+        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
+        ArticleStorage articleStorage = new DataDirectoryArticleStorage(getTempFilePath("articles"));
+        Storage storageManager = new StorageManager(addressBookStorage, userPrefsStorage, articleStorage);
+        modelManager = new ModelManager(new EntryBook(), new UserPrefs(), storageManager);
+        modelManager.addPerson(VALID_FILE_LINK);
+        String content = new String(
+                Files.readAllBytes(
+                        modelManager
+                                .getStorage()
+                                .getArticlePath(VALID_FILE_LINK.getLink().value)),
+                StandardCharsets.UTF_8);
+        assertEquals(FILE_TEST_CONTENTS, content);
+    }
+
+    private Path getTempFilePath(String fileName) {
+        return testFolder.getRoot().toPath().resolve(fileName);
     }
 }

--- a/src/test/java/seedu/address/model/UserPrefsTest.java
+++ b/src/test/java/seedu/address/model/UserPrefsTest.java
@@ -18,4 +18,10 @@ public class UserPrefsTest {
         Assert.assertThrows(NullPointerException.class, () -> userPrefs.setAddressBookFilePath(null));
     }
 
+    @Test
+    public void setArticleDataDirectoryPath_nullPath_throwsNullPointerException() {
+        UserPrefs userPrefs = new UserPrefs();
+        Assert.assertThrows(NullPointerException.class, () -> userPrefs.setArticleDataDirectoryPath(null));
+    }
+
 }

--- a/src/test/java/seedu/address/network/NetworkTest.java
+++ b/src/test/java/seedu/address/network/NetworkTest.java
@@ -6,6 +6,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static seedu.address.network.Network.fetchAsStream;
 import static seedu.address.network.Network.fetchAsString;
+import static seedu.address.testutil.TypicalEntries.FILE_TEST_CONTENTS;
+import static seedu.address.testutil.TypicalEntries.VALID_FILE_LINK;
+import static seedu.address.testutil.TypicalEntries.VALID_HTTPS_LINK;
+import static seedu.address.testutil.TypicalEntries.VALID_HTTP_LINK;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,27 +22,27 @@ import org.junit.rules.ExpectedException;
 import seedu.address.MainApp;
 
 public class NetworkTest {
+    private static final String HTTPS_TEST_URL = VALID_HTTPS_LINK.getLink().value;
+    private static final String HTTP_TEST_URL = VALID_HTTP_LINK.getLink().value;
+    private static final String FILE_TEST_URL = VALID_FILE_LINK.getLink().value;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private String localTestContents = "<!DOCTYPE html>\n<html>\n</html>\n";
-
     @Test
     public void fetchAsStream_success() throws IOException {
-        InputStream httpsContent = fetchAsStream("https://cs2103-ay1819s2-w10-1.github.io/main/networktests/");
+        InputStream httpsContent = fetchAsStream(HTTPS_TEST_URL);
         byte[] httpsContentBytes = httpsContent.readAllBytes();
         assertTrue(httpsContentBytes.length > 0);
         assertTrue(new String(httpsContentBytes, StandardCharsets.UTF_8).contains("<p>It works!</p>"));
 
-        InputStream httpContent = fetchAsStream("http://cs2103-ay1819s2-w10-1.github.io/main/networktests/");
+        InputStream httpContent = fetchAsStream(HTTP_TEST_URL);
         assertTrue(httpContent.readAllBytes().length > 0);
 
-        InputStream localContent = fetchAsStream(MainApp.class.getResource(
-                "/view/NetworkTest/default.html").toExternalForm());
+        InputStream localContent = fetchAsStream(FILE_TEST_URL);
         byte[] localContentBytes = localContent.readAllBytes();
         assertTrue(localContentBytes.length > 0);
-        assertArrayEquals(localContentBytes, localTestContents.getBytes());
+        assertArrayEquals(localContentBytes, FILE_TEST_CONTENTS.getBytes());
     }
 
     @Test
@@ -67,7 +71,7 @@ public class NetworkTest {
                     MainApp.class.getResource("/view/NetworkTest/default.html").toExternalForm());
             assertTrue(localContent.length() > 0);
 
-            assertEquals(localContent, localTestContents);
+            assertEquals(localContent, FILE_TEST_CONTENTS);
         } catch (IOException e) {
             fail("Fetching valid URL failed.");
         }

--- a/src/test/java/seedu/address/storage/DataDirectoryArticleStorageTest.java
+++ b/src/test/java/seedu/address/storage/DataDirectoryArticleStorageTest.java
@@ -1,0 +1,76 @@
+package seedu.address.storage;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+public class DataDirectoryArticleStorageTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder testFolder = new TemporaryFolder();
+
+    @Test
+    public void addArticle_nullDirectoryPath_throwsNullPointerException() throws IOException {
+        thrown.expect(NullPointerException.class);
+        DataDirectoryArticleStorage ddas = new DataDirectoryArticleStorage(null);
+        ddas.addArticle("https://test.com", "test".getBytes());
+    }
+
+    @Test
+    public void addArticle_contentSavedAtPathCorrectly() throws IOException {
+        DataDirectoryArticleStorage ddas = new DataDirectoryArticleStorage(testFolder.getRoot().toPath());
+
+        // Save a bunch of articles then fetch them. They shouldn't overwrite each other.
+
+        ddas.addArticle("https://test.com", "test1".getBytes());
+        ddas.addArticle("https://test.com/article", "test2".getBytes());
+        ddas.addArticle("https://test.com/article.html", "test3".getBytes());
+        ddas.addArticle("https://test.io", "test4".getBytes());
+        ddas.addArticle("https://test.io/article", "test5".getBytes());
+        ddas.addArticle("https://test.io/article.html", "test6".getBytes());
+        ddas.addArticle("http://test.io", "test7".getBytes());
+        ddas.addArticle("http://test.io/article", "test8".getBytes());
+        ddas.addArticle("http://test.io/article.html", "test9".getBytes());
+
+        assertFetchSuccess(ddas, "https://test.com", "test1".getBytes());
+        assertFetchSuccess(ddas, "https://test.com/article", "test2".getBytes());
+        assertFetchSuccess(ddas, "https://test.com/article.html", "test3".getBytes());
+        assertFetchSuccess(ddas, "https://test.io", "test4".getBytes());
+        assertFetchSuccess(ddas, "https://test.io/article", "test5".getBytes());
+        assertFetchSuccess(ddas, "https://test.io/article.html", "test6".getBytes());
+        assertFetchSuccess(ddas, "http://test.io", "test7".getBytes());
+        assertFetchSuccess(ddas, "http://test.io/article", "test8".getBytes());
+        assertFetchSuccess(ddas, "http://test.io/article.html", "test9".getBytes());
+    }
+
+    @Test
+    public void addArticle_addingTwiceOverwritesContent() throws IOException {
+        DataDirectoryArticleStorage ddas = new DataDirectoryArticleStorage(testFolder.getRoot().toPath());
+
+        // Save a bunch of articles then fetch them. They shouldn't overwrite each other.
+
+        ddas.addArticle("https://test.com", "test1".getBytes());
+        assertFetchSuccess(ddas, "https://test.com", "test1".getBytes());
+
+        ddas.addArticle("https://test.com", "test2".getBytes());
+        assertFetchSuccess(ddas, "https://test.com", "test2".getBytes());
+    }
+
+    /**
+     * Checks that the content saved for the URL matches.
+     */
+    private void assertFetchSuccess(DataDirectoryArticleStorage ddas, String url, byte[] content) throws IOException {
+        Path savedLocation = ddas.getArticlePath(url);
+        assertArrayEquals(Files.readAllBytes(savedLocation), content);
+    }
+}

--- a/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
@@ -84,6 +84,7 @@ public class JsonUserPrefsStorageTest {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
         userPrefs.setAddressBookFilePath(Paths.get("addressbook.json"));
+        userPrefs.setArticleDataDirectoryPath(Paths.get("data"));
         return userPrefs;
     }
 

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -2,8 +2,10 @@ package seedu.address.storage;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static seedu.address.testutil.TypicalEntries.getTypicalAddressBook;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.junit.Before;
@@ -27,7 +29,8 @@ public class StorageManagerTest {
     public void setUp() {
         JsonEntryBookStorage addressBookStorage = new JsonEntryBookStorage(getTempFilePath("ab"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(getTempFilePath("prefs"));
-        storageManager = new StorageManager(addressBookStorage, userPrefsStorage);
+        ArticleStorage articleStorage = new DataDirectoryArticleStorage(getTempFilePath("articles"));
+        storageManager = new StorageManager(addressBookStorage, userPrefsStorage, articleStorage);
     }
 
     private Path getTempFilePath(String fileName) {
@@ -60,6 +63,20 @@ public class StorageManagerTest {
         storageManager.saveAddressBook(original);
         ReadOnlyEntryBook retrieved = storageManager.readAddressBook().get();
         assertEquals(original, new EntryBook(retrieved));
+    }
+
+    @Test
+    public void articleStorageReadSave() throws Exception {
+        /*
+         * Note: This is an integration test that verifies the StorageManager is properly wired to the
+         * {@link DataDirectoryArticleStorage} class.
+         * More extensive testing of article saving/reading is done in {@link DataDirectoryArticleStorageTest} class.
+         */
+        String testUrl = "https://test.url";
+        byte[] testContent = "test content".getBytes();
+        storageManager.addArticle(testUrl, testContent);
+        Path savedArticlePath = storageManager.getArticlePath(testUrl);
+        assertArrayEquals(Files.readAllBytes(savedArticlePath), testContent);
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -84,4 +84,9 @@ public class StorageManagerTest {
         assertNotNull(storageManager.getAddressBookFilePath());
     }
 
+    @Test
+    public void getArticleDataDirectoryPath() {
+        assertNotNull(storageManager.getArticleDataDirectoryPath());
+    }
+
 }

--- a/src/test/java/seedu/address/testutil/TypicalEntries.java
+++ b/src/test/java/seedu/address/testutil/TypicalEntries.java
@@ -116,6 +116,28 @@ public class TypicalEntries {
             .withTags(VALID_TAG_SCIENCE, VALID_TAG_TECH)
             .build();
 
+    // For testing of networking
+    public static final Entry VALID_HTTPS_LINK = new EntryBuilder()
+            .withName("Valid https Link")
+            .withPhone("Valid https link")
+            .withEmail("https://cs2103-ay1819s2-w10-1.github.io/main/networktests/")
+            .withAddress("Valid https link")
+            .build();
+    public static final Entry VALID_HTTP_LINK = new EntryBuilder()
+            .withName("Valid https Link")
+            .withPhone("Valid https link")
+            .withEmail("http://cs2103-ay1819s2-w10-1.github.io/main/networktests/")
+            .withAddress("Valid https link")
+            .build();
+    public static final Entry VALID_FILE_LINK = new EntryBuilder()
+            .withName("Valid file Link")
+            .withPhone("Valid file link")
+            .withEmail("file://" + MainApp.class.getResource(
+            "/view/NetworkTest/default.html").toExternalForm().substring(5))
+            .withAddress("Valid file link")
+            .build();
+    public static final String FILE_TEST_CONTENTS = "<!DOCTYPE html>\n<html>\n</html>\n";
+
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 
     private TypicalEntries() {} // prevents instantiation


### PR DESCRIPTION
Resolves #22.

Next part after this is to allow loading of local webpages into the WebView.

# Summary of changes

- Added ArticleStorage and related classes to manage saving articles to disk. No articles are kept in memory. Instead, a Path can be obtained in order to load the article required into a WebView.
- Modified UserPrefs and Model accordingly to include the right paths and methods for ArticleStorage.
- Refactored URLs used for Network tests into TypicalEntries.
- Added unit and integration tests.
- Connected article saving to the `add` command.