### PR TITLE
Stage files for network tests in gh pages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,6 +232,15 @@ task copyStylesheets(type: Copy) {
 }
 asciidoctor.dependsOn copyStylesheets
 
+// Copies files needed for network tests into the generated HTML files to
+// use github pages for network testing.
+// This is needed as asciidoctor does not deploy non-asciidoc blobs.
+task copyNetworktestFiles(type: Copy) {
+    from "${asciidoctor.sourceDir}/networktests"
+    into "${asciidoctor.outputDir}/html5/networktests"
+}
+asciidoctor.dependsOn copyNetworktestFiles
+
 task deployOfflineDocs(type: Copy) {
     into('src/main/resources/docs')
 

--- a/docs/networktests/index.html
+++ b/docs/networktests/index.html
@@ -1,0 +1,3 @@
+<html>
+<p>It works!</p>
+</html>

--- a/docs/networktests/notafeed.notxml
+++ b/docs/networktests/notafeed.notxml
@@ -1,0 +1,3 @@
+this is not an rss feed
+
+blahbla

--- a/docs/networktests/rss.xml
+++ b/docs/networktests/rss.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+
+<channel>
+<title>Anime Revies</title>
+<link>https://blog.GNU.moe/anime</link>
+<description>
+My stupid and completely irrelevant anime reviews.
+</description>
+<image>https://blog.GNU.moe/anime/icon.svg</image>
+<author>
+Tsutsukakushi Tsukiko &lt;yui@cock.li&gt; (7B29 6212 4A73 E1E9 15E8  A7D4 7F96 C964 9CBC BF51)
+</author>
+<copyright>
+CC0 &lt;https://creativecommons.org/publicdomain/zero/1.0/legalcode&gt;
+</copyright>
+<lastBuildDate>Sun May 27 04:15:47 EEST 2018</lastBuildDate>
+<item>
+<title>Anime: Mahoujin Guru Guru  </title>
+<link>https://blog.GNU.moe/anime/review/mahoujin-guru-guru.html</link>
+<pubDate>Wed Jan 10 03:01:02 2018 +0200</pubDate>
+<description><![CDATA[
+Anime review 1
+]]></description>
+</item>
+<item>
+<title>Anime: Gamers!  </title>
+<link>https://blog.GNU.moe/anime/review/gamers.html</link>
+<pubDate>Wed Jan 10 03:01:02 2018 +0200</pubDate>
+<description><![CDATA[
+Anime review 2
+]]></description>
+</item>
+<item>
+<title>Anime: Made in Abyss  </title>
+<link>https://blog.GNU.moe/anime/review/made-in-abyss.html</link>
+<pubDate>Wed Jan 10 03:01:02 2018 +0200</pubDate>
+<description><![CDATA[
+Anime review n
+]]></description>
+</item>
+<item>
+<title>Anime: Mob Psycho 100  </title>
+<link>https://blog.GNU.moe/anime/review/mob-psycho.html</link>
+<pubDate>Wed Jan 10 03:01:02 2018 +0200</pubDate>
+<description><![CDATA[
+Anime review
+]]></description>
+</item>
+<item>
+<title>Anime: New Game!!  </title>
+<link>https://blog.GNU.moe/anime/review/new-game-2.html</link>
+<pubDate>Wed Jan 10 03:01:02 2018 +0200</pubDate>
+<description><![CDATA[
+Anime revieww
+]]></description>
+</item>
+<item>
+<title>Anime: Saiki Kusuo no Psi-nan  </title>
+<link>https://blog.GNU.moe/anime/review/saiki-kusuo.html</link>
+<pubDate>Wed Jan 10 03:01:02 2018 +0200</pubDate>
+<description><![CDATA[
+sigh
+]]></description>
+</item>
+<item>
+<title>Anime: Durarara!!  </title>
+<link>https://blog.GNU.moe/anime/review/durarara.html</link>
+<pubDate>Wed Jan 10 03:01:02 2018 +0200</pubDate>
+<description><![CDATA[
+]]></description>
+</item>
+<item>
+<title>Anime: Battle Programmer Shirase  </title>
+<link>https://blog.GNU.moe/anime/review/bps.html</link>
+<pubDate>Wed Jan 10 03:01:02 2018 +0200</pubDate>
+<description><![CDATA[
+lol
+]]></description>
+</item>
+<item>
+<title>Anime: Re:Zero  </title>
+<link>https://blog.GNU.moe/anime/review/re_zero.html</link>
+<pubDate>Wed Jan 10 03:01:02 2018 +0200</pubDate>
+<description><![CDATA[
+idk
+]]></description>
+</item>
+<item>
+<title>Anime: Youjo Senki  </title>
+<link>https://blog.GNU.moe/anime/review/youjo_senki.html</link>
+<pubDate>Wed Jan 10 03:01:02 2018 +0200</pubDate>
+<description><![CDATA[
+I like this reviewer
+]]></description>
+</item>
+</channel>
+</rss>


### PR DESCRIPTION
I shouldn't be using my own server for network-based tests...

Summary
----------
This sets up the infrastructure for more flexible network tests. Drop the test files in `/docs/networktests/` and they will be deployed in `GH_PAGES_URL/networktests/`.