### PR TITLE
FeedCommandTest: Update URLs to point to GH pages.

### DIFF
--- a/src/test/java/seedu/address/logic/commands/FeedCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FeedCommandTest.java
@@ -26,12 +26,13 @@ import seedu.address.model.entry.Link;
 import seedu.address.model.entry.Title;
 
 public class FeedCommandTest {
-    private static final String TEST_URL = "https://m4th.b0ss.net/temp/rss.xml";
+    private static final String TEST_URL = "https://cs2103-ay1819s2-w10-1.github.io/main/networktests/rss.xml";
     private static final String TEST_URL_LOCAL = MainApp.class.getResource("/RssFeedTest/rss.xml")
             .toExternalForm();
 
     private static final String MALFORMED_URL = "notavalidprotocol://malformed.url/invalid";
-    private static final String NOTAFEED_URL = "https://m4th.b0ss.net/temp/notafeed.notxml";
+    private static final String NOTAFEED_URL =
+        "https://cs2103-ay1819s2-w10-1.github.io/main/networktests/notafeed.notxml";
 
     private Model model = new ModelManagerStub();
     private CommandHistory commandHistory = new CommandHistory();

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -68,7 +68,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseName_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseTitle((Optional) null));
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseTitle((Optional<String>) null));
     }
 
     @Test
@@ -91,7 +91,7 @@ public class ParserUtilTest {
 
     @Test
     public void parsePhone_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseDescription((Optional) null));
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseDescription((Optional<String>) null));
     }
 
     @Test
@@ -140,7 +140,7 @@ public class ParserUtilTest {
 
     @Test
     public void parseEmail_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseLink((Optional) null));
+        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseLink((Optional<String>) null));
     }
 
     @Test


### PR DESCRIPTION
* Point URLs in FeedCommandTest to the (not yet up) gh pages link (follow-up to #64)
* Silence unchecked exception warnings for ParserUtilTest