### PR TITLE
Add context swinging

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -16,9 +16,6 @@ import seedu.address.ui.ViewMode;
  * API of the Logic component
  */
 public interface Logic {
-    static int PARSER_CONTEXT_LIST = 0;
-    static int PARSER_CONTEXT_ARCHIVE = 1;
-
     /**
      * Executes the command and returns the result.
      * @param commandText The command as entered by the user.

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -16,6 +16,9 @@ import seedu.address.ui.ViewMode;
  * API of the Logic component
  */
 public interface Logic {
+    static int PARSER_CONTEXT_LIST = 0;
+    static int PARSER_CONTEXT_ARCHIVE = 1;
+
     /**
      * Executes the command and returns the result.
      * @param commandText The command as entered by the user.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -41,11 +41,11 @@ public class LogicManager implements Logic {
         CommandResult commandResult;
 
         switch (model.getContext()) {
-        case Model.PARSER_CONTEXT_LIST:
+        case CONTEXT_LIST:
             entryBookParser = new EntryBookListParser();
             break;
 
-        case Model.PARSER_CONTEXT_ARCHIVE:
+        case CONTEXT_ARCHIVE:
             entryBookParser = new EntryBookArchivesParser();
             break;
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -23,6 +23,8 @@ import seedu.address.ui.ViewMode;
 public class LogicManager implements Logic {
     private final Logger logger = LogsCenter.getLogger(LogicManager.class);
 
+    private int state = Logic.PARSER_CONTEXT_LIST;
+
     private final Model model;
     private final CommandHistory history;
     private final EntryBookParser entryBookParser;

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -23,8 +23,6 @@ import seedu.address.ui.ViewMode;
 public class LogicManager implements Logic {
     private final Logger logger = LogsCenter.getLogger(LogicManager.class);
 
-    private int state = Logic.PARSER_CONTEXT_LIST;
-
     private final Model model;
     private final CommandHistory history;
     private final EntryBookParser entryBookParser;

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -10,6 +10,8 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.EntryBookArchivesParser;
+import seedu.address.logic.parser.EntryBookListParser;
 import seedu.address.logic.parser.EntryBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
@@ -25,19 +27,32 @@ public class LogicManager implements Logic {
 
     private final Model model;
     private final CommandHistory history;
-    private final EntryBookParser entryBookParser;
 
     public LogicManager(Model model) {
         this.model = model;
         history = new CommandHistory();
-        entryBookParser = new EntryBookParser();
     }
 
     @Override
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
+        EntryBookParser entryBookParser;
         CommandResult commandResult;
+
+        switch (model.getContext()) {
+        case Model.PARSER_CONTEXT_LIST:
+            entryBookParser = new EntryBookListParser();
+            break;
+
+        case Model.PARSER_CONTEXT_ARCHIVE:
+            entryBookParser = new EntryBookArchivesParser();
+            break;
+
+        default:
+            entryBookParser = new EntryBookParser();
+        }
+
         try {
             Command command = entryBookParser.parseCommand(commandText);
             commandResult = command.execute(model, history);

--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.entry.Entry;
+
+/**
+ * Lists all entries in the archives to the user.
+ */
+public class ArchiveCommand extends Command {
+
+    public static final String COMMAND_WORD = "archive";
+    public static final String COMMAND_ALIAS = "arch";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Archives the entry identified by the index number used in the displayed entry list.\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_ARCHIVE_ENTRY_SUCCESS = "Entry archived: %1$s";
+
+    private final Index targetIndex;
+
+    public ArchiveCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+        List<Entry> lastShownList = model.getFilteredEntryList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Entry entryToArchive = lastShownList.get(targetIndex.getZeroBased());
+        return new CommandResult(String.format(MESSAGE_ARCHIVE_ENTRY_SUCCESS, entryToArchive));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -45,4 +45,10 @@ public class ArchiveCommand extends Command {
         return new CommandResult(String.format(MESSAGE_ARCHIVE_ENTRY_SUCCESS, entryToArchive));
     }
 
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof ArchiveCommand // instanceof handles nulls
+            && targetIndex.equals(((ArchiveCommand) other).targetIndex)); // state check
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/ArchivesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchivesCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
 
 /**
  * Lists all entries in the archives to the user.
@@ -19,7 +20,7 @@ public class ArchivesCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        model.setContext(Model.PARSER_CONTEXT_ARCHIVE);
+        model.setContext(ModelContext.CONTEXT_ARCHIVE);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ArchivesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchivesCommand.java
@@ -1,0 +1,25 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+
+/**
+ * Lists all entries in the archives to the user.
+ */
+public class ArchivesCommand extends Command {
+
+    public static final String COMMAND_WORD = "archives";
+    public static final String COMMAND_ALIAS = "archs";
+
+    public static final String MESSAGE_SUCCESS = "Listed all entries in archives";
+
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) {
+        requireNonNull(model);
+        // TODO: Does nothing for now
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ArchivesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchivesCommand.java
@@ -13,13 +13,13 @@ public class ArchivesCommand extends Command {
     public static final String COMMAND_WORD = "archives";
     public static final String COMMAND_ALIAS = "archs";
 
-    public static final String MESSAGE_SUCCESS = "Listed all entries in archives";
+    public static final String MESSAGE_SUCCESS = "Context switched to archive-context. Listed all entries in archives.";
 
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        // TODO: Does nothing for now
+        model.setContext(Model.PARSER_CONTEXT_ARCHIVE);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -5,6 +5,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
 
 /**
  * Lists all persons in the address book to the user.
@@ -20,7 +21,7 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
-        model.setContext(Model.PARSER_CONTEXT_LIST);
+        model.setContext(ModelContext.CONTEXT_LIST);
         model.updateFilteredEntryList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -14,12 +14,13 @@ public class ListCommand extends Command {
     public static final String COMMAND_WORD = "list";
     public static final String COMMAND_ALIAS = "l";
 
-    public static final String MESSAGE_SUCCESS = "Listed all entries";
+    public static final String MESSAGE_SUCCESS = "Context switched to list-context. Listed all entries";
 
 
     @Override
     public CommandResult execute(Model model, CommandHistory history) {
         requireNonNull(model);
+        model.setContext(Model.PARSER_CONTEXT_LIST);
         model.updateFilteredEntryList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);
     }

--- a/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
@@ -45,4 +45,11 @@ public class UnarchiveCommand extends Command {
         return new CommandResult(String.format(MESSAGE_UNARCHIVE_ENTRY_SUCCESS, entryToUnarchive));
     }
 
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof UnarchiveCommand // instanceof handles nulls
+            && targetIndex.equals(((UnarchiveCommand) other).targetIndex)); // state check
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
@@ -1,0 +1,48 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.entry.Entry;
+
+/**
+ * Lists all entries in the archives to the user.
+ */
+public class UnarchiveCommand extends Command {
+
+    public static final String COMMAND_WORD = "unarchive";
+    public static final String COMMAND_ALIAS = "unarch";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Un-archives the entry identified by the index number used in the displayed entry list.\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_UNARCHIVE_ENTRY_SUCCESS = "Entry unarchived: %1$s";
+
+    private final Index targetIndex;
+
+    public UnarchiveCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+        List<Entry> lastShownList = model.getFilteredEntryList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Entry entryToUnarchive = lastShownList.get(targetIndex.getZeroBased());
+        return new CommandResult(String.format(MESSAGE_UNARCHIVE_ENTRY_SUCCESS, entryToUnarchive));
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ArchiveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ArchiveCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ArchiveCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ArchiveCommand object
+ */
+public class ArchiveCommandParser implements Parser<ArchiveCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ArchiveCommand
+     * and returns an ArchiveCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ArchiveCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new ArchiveCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ArchiveCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/EntryBookArchivesParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookArchivesParser.java
@@ -6,6 +6,7 @@ import java.util.regex.Matcher;
 
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.UnarchiveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -31,6 +32,10 @@ public class EntryBookArchivesParser extends EntryBookParser {
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
+
+        case UnarchiveCommand.COMMAND_WORD:
+        case UnarchiveCommand.COMMAND_ALIAS:
+            return new UnarchiveCommandParser().parse(arguments);
 
         default:
             return super.parseCommand(userInput);

--- a/src/main/java/seedu/address/logic/parser/EntryBookArchivesParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookArchivesParser.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.regex.Matcher;
+
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Represents the parser for the archive-context.
+ * It successfully parses a command if and only if the command is archive-context command.
+ */
+public class EntryBookArchivesParser extends EntryBookParser {
+
+    /**
+     * Parses user input into command for execution.
+     * Parses successfully if and only if the command is archive-context command.
+     *
+     * @param userInput full user input string
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public Command parseCommand(String userInput) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String commandWord = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+        switch (commandWord) {
+
+        default:
+            return super.parseCommand(userInput);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import java.util.regex.Matcher;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ArchiveCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -43,6 +44,10 @@ public class EntryBookListParser extends EntryBookParser {
         case AddCommand.COMMAND_WORD:
         case AddCommand.COMMAND_ALIAS:
             return new AddCommandParser().parse(arguments);
+
+        case ArchiveCommand.COMMAND_WORD:
+        case ArchiveCommand.COMMAND_ALIAS:
+            return new ArchiveCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
         case EditCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
@@ -1,0 +1,77 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.regex.Matcher;
+
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.FeedCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.ViewModeCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Represents the parser for the list-context.
+ * It successfully parses a command if and only if the command is list-context command.
+ */
+public class EntryBookListParser extends EntryBookParser {
+
+    /**
+     * Parses user input into command for execution.
+     * Parses successfully if and only if the command is list-context command.
+     *
+     * @param userInput full user input string
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public Command parseCommand(String userInput) throws ParseException {
+        final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
+        if (!matcher.matches()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        }
+
+        final String commandWord = matcher.group("commandWord");
+        final String arguments = matcher.group("arguments");
+        switch (commandWord) {
+
+        case AddCommand.COMMAND_WORD:
+        case AddCommand.COMMAND_ALIAS:
+            return new AddCommandParser().parse(arguments);
+
+        case EditCommand.COMMAND_WORD:
+        case EditCommand.COMMAND_ALIAS:
+            return new EditCommandParser().parse(arguments);
+
+        case SelectCommand.COMMAND_WORD:
+        case SelectCommand.COMMAND_ALIAS:
+            return new SelectCommandParser().parse(arguments);
+
+        case DeleteCommand.COMMAND_WORD:
+            return new DeleteCommandParser().parse(arguments);
+
+        case ClearCommand.COMMAND_WORD:
+            return new ClearCommand();
+
+        case FindCommand.COMMAND_WORD:
+        case FindCommand.COMMAND_ALIAS:
+            return new FindCommandParser().parse(arguments);
+
+        case ViewModeCommand.COMMAND_WORD:
+        case ViewModeCommand.COMMAND_ALIAS:
+            return new ViewModeCommandParser().parse(arguments);
+
+        case FeedCommand.COMMAND_WORD:
+            return new FeedCommandParser().parse(arguments);
+
+        default:
+            return super.parseCommand(userInput);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/EntryBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookParser.java
@@ -6,35 +6,30 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ArchivesCommand;
-import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FeedCommand;
-import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.SelectCommand;
-import seedu.address.logic.commands.ViewModeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
+
 /**
- * Parses user input.
+ * Represents the base parser for any context.
+ * It successfully parses a command if and only if the command is context-switching, exit, help or history.
  */
 public class EntryBookParser {
 
     /**
      * Used for initial separation of command word and args.
      */
-    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+    protected static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
     /**
      * Parses user input into command for execution.
-     *
+     * Parses successfully if and only if the command is context-switching, exit, help or history.
+
      * @param userInput full user input string
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
@@ -49,52 +44,23 @@ public class EntryBookParser {
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
 
-        case AddCommand.COMMAND_WORD:
-        case AddCommand.COMMAND_ALIAS:
-            return new AddCommandParser().parse(arguments);
-
-        case EditCommand.COMMAND_WORD:
-        case EditCommand.COMMAND_ALIAS:
-            return new EditCommandParser().parse(arguments);
-
-        case SelectCommand.COMMAND_WORD:
-        case SelectCommand.COMMAND_ALIAS:
-            return new SelectCommandParser().parse(arguments);
-
-        case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
-
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
-
-        case FindCommand.COMMAND_WORD:
-        case FindCommand.COMMAND_ALIAS:
-            return new FindCommandParser().parse(arguments);
+        case ArchivesCommand.COMMAND_WORD:
+            return new ArchivesCommand();
 
         case ListCommand.COMMAND_WORD:
         case ListCommand.COMMAND_ALIAS:
             return new ListCommand();
 
+        case ExitCommand.COMMAND_WORD:
+            return new ExitCommand();
+
         case HistoryCommand.COMMAND_WORD:
         case HistoryCommand.COMMAND_ALIAS:
             return new HistoryCommand();
 
-        case ExitCommand.COMMAND_WORD:
-            return new ExitCommand();
-
         case HelpCommand.COMMAND_WORD:
         case HelpCommand.COMMAND_ALIAS:
             return new HelpCommand();
-
-        case ViewModeCommand.COMMAND_WORD:
-        case ViewModeCommand.COMMAND_ALIAS:
-            return new ViewModeCommandParser().parse(arguments);
-
-        case FeedCommand.COMMAND_WORD:
-            return new FeedCommandParser().parse(arguments);
-
-        case ArchivesCommand.COMMAND_WORD:
-            return new ArchivesCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/EntryBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ArchivesCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -91,6 +92,9 @@ public class EntryBookParser {
 
         case FeedCommand.COMMAND_WORD:
             return new FeedCommandParser().parse(arguments);
+
+        case ArchivesCommand.COMMAND_WORD:
+            return new ArchivesCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/EntryBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookParser.java
@@ -45,6 +45,7 @@ public class EntryBookParser {
         switch (commandWord) {
 
         case ArchivesCommand.COMMAND_WORD:
+        case ArchivesCommand.COMMAND_ALIAS:
             return new ArchivesCommand();
 
         case ListCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/UnarchiveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnarchiveCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.UnarchiveCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new UnarchiveCommand object
+ */
+public class UnarchiveCommandParser implements Parser<UnarchiveCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the UnarchiveCommand
+     * and returns an UnarchiveCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public UnarchiveCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new UnarchiveCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnarchiveCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -15,6 +15,9 @@ import seedu.address.ui.ViewMode;
  * The API of the Model component.
  */
 public interface Model {
+    static final int PARSER_CONTEXT_LIST = 0;
+    static final int PARSER_CONTEXT_ARCHIVE = 1;
+
     /** {@code Predicate} that always evaluate to true */
     Predicate<Entry> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -15,8 +15,6 @@ import seedu.address.ui.ViewMode;
  * The API of the Model component.
  */
 public interface Model {
-    static final int PARSER_CONTEXT_LIST = 0;
-    static final int PARSER_CONTEXT_ARCHIVE = 1;
 
     /** {@code Predicate} that always evaluate to true */
     Predicate<Entry> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
@@ -188,11 +186,11 @@ public interface Model {
     /**
      * Returns the context of the Model.
      */
-    int getContext();
+    ModelContext getContext();
 
     /**
      * Sets the context of the Model.
      * @param context
      */
-    void setContext(int context);
+    void setContext(ModelContext context);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -193,4 +193,16 @@ public interface Model {
      * @param context
      */
     void setContext(ModelContext context);
+
+    /**
+     * Archives the given entry.
+     * The entry must exist in the entry book.
+     */
+    void archiveEntry(Entry target);
+
+    /**
+     * Un-archives the given entry.
+     * The entry must exist in the entry book archives.
+     */
+    void unarchiveEntry(Entry entry);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -181,4 +181,15 @@ public interface Model {
      * Mainly created because clone is needed a lot in tests.
      */
     Model clone();
+
+    /**
+     * Returns the context of the Model.
+     */
+    int getContext();
+
+    /**
+     * Sets the context of the Model.
+     * @param context
+     */
+    void setContext(int context);
 }

--- a/src/main/java/seedu/address/model/ModelContext.java
+++ b/src/main/java/seedu/address/model/ModelContext.java
@@ -1,0 +1,8 @@
+package seedu.address.model;
+
+/**
+ * Enums for contexts Model can take
+ */
+public enum ModelContext {
+    CONTEXT_LIST, CONTEXT_ARCHIVE
+}

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -31,9 +31,6 @@ import seedu.address.ui.ViewMode;
 public class ModelManager implements Model {
     public static final String FILE_OPS_ERROR_MESSAGE = "Could not save data to file: ";
 
-    public static final int PARSER_CONTEXT_LIST = 0;
-    public static final int PARSER_CONTEXT_ARCHIVE = 1;
-
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
     private int context = PARSER_CONTEXT_LIST;
@@ -345,4 +342,5 @@ public class ModelManager implements Model {
     public int getContext() {
         return context;
     }
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -31,7 +31,12 @@ import seedu.address.ui.ViewMode;
 public class ModelManager implements Model {
     public static final String FILE_OPS_ERROR_MESSAGE = "Could not save data to file: ";
 
+    public static final int PARSER_CONTEXT_LIST = 0;
+    public static final int PARSER_CONTEXT_ARCHIVE = 1;
+
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
+
+    private int context = PARSER_CONTEXT_LIST;
 
     private final EntryBook entryBook;
     private final UserPrefs userPrefs;
@@ -331,4 +336,13 @@ public class ModelManager implements Model {
         return new ModelManager(this.entryBook, this.userPrefs, this.storage);
     }
 
+    @Override
+    public void setContext(int context) {
+        this.context = context;
+    }
+
+    @Override
+    public int getContext() {
+        return context;
+    }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -330,7 +330,9 @@ public class ModelManager implements Model {
 
     @Override
     public Model clone() {
-        return new ModelManager(this.entryBook, this.userPrefs, this.storage);
+        Model clonedModel = new ModelManager(this.entryBook, this.userPrefs, this.storage);
+        clonedModel.setContext(this.getContext());
+        return clonedModel;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -343,4 +343,13 @@ public class ModelManager implements Model {
         return context;
     }
 
+    @Override
+    public void archiveEntry(Entry target) {
+        return;
+    }
+
+    @Override
+    public void unarchiveEntry(Entry entry) {
+        return;
+    }
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -33,7 +33,7 @@ public class ModelManager implements Model {
 
     private static final Logger logger = LogsCenter.getLogger(ModelManager.class);
 
-    private int context = PARSER_CONTEXT_LIST;
+    private ModelContext context = ModelContext.CONTEXT_LIST;
 
     private final EntryBook entryBook;
     private final UserPrefs userPrefs;
@@ -334,12 +334,12 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void setContext(int context) {
+    public void setContext(ModelContext context) {
         this.context = context;
     }
 
     @Override
-    public int getContext() {
+    public ModelContext getContext() {
         return context;
     }
 

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -94,7 +94,8 @@ public class TestApp extends MainApp {
      * Returns a defensive copy of the model.
      */
     public Model getModel() {
-        Model copy = model.clone();
+        Model copy = new ModelManager(model.getEntryBook(), new UserPrefs(), new StorageStub());
+        copy.setContext(model.getContext());
         ModelHelper.setFilteredList(copy, model.getFilteredEntryList());
         return copy;
     }

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -94,7 +94,7 @@ public class TestApp extends MainApp {
      * Returns a defensive copy of the model.
      */
     public Model getModel() {
-        Model copy = new ModelManager((model.getEntryBook()), new UserPrefs(), new StorageStub());
+        Model copy = model.clone();
         ModelHelper.setFilteredList(copy, model.getFilteredEntryList());
         return copy;
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -251,6 +251,16 @@ public class AddCommandTest {
         public Model clone() {
             return this;
         }
+
+        @Override
+        public int getContext() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setContext(int context) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -21,6 +21,7 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
 import seedu.address.model.ReadOnlyEntryBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.entry.Entry;
@@ -253,12 +254,22 @@ public class AddCommandTest {
         }
 
         @Override
-        public int getContext() {
+        public ModelContext getContext() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
-        public void setContext(int context) {
+        public void setContext(ModelContext context) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void archiveEntry(Entry target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void unarchiveEntry(Entry entry) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/parser/EntryBookArchivesParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookArchivesParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -13,13 +14,14 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UnarchiveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 public class EntryBookArchivesParserTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private final EntryBookListParser parser = new EntryBookListParser();
+    private final EntryBookArchivesParser parser = new EntryBookArchivesParser();
 
     @Test
     public void parseCommand_exit() throws Exception {
@@ -56,6 +58,13 @@ public class EntryBookArchivesParserTest {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_ALIAS) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_ALIAS + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_unarchive() throws Exception {
+        UnarchiveCommand command = (UnarchiveCommand) parser.parseCommand(
+            UnarchiveCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new UnarchiveCommand(INDEX_FIRST_ENTRY), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EntryBookArchivesParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookArchivesParserTest.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.parser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.HistoryCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class EntryBookArchivesParserTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final EntryBookListParser parser = new EntryBookListParser();
+
+    @Test
+    public void parseCommand_exit() throws Exception {
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+    }
+
+    @Test
+    public void parseCommand_help() throws Exception {
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_ALIAS) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_ALIAS + " 3") instanceof HelpCommand);
+    }
+
+    @Test
+    public void parseCommand_history() throws Exception {
+        assertTrue(parser.parseCommand(HistoryCommand.COMMAND_WORD) instanceof HistoryCommand);
+        assertTrue(parser.parseCommand(HistoryCommand.COMMAND_WORD + " 3") instanceof HistoryCommand);
+        assertTrue(parser.parseCommand(HistoryCommand.COMMAND_ALIAS) instanceof HistoryCommand);
+        assertTrue(parser.parseCommand(HistoryCommand.COMMAND_ALIAS + " 3") instanceof HistoryCommand);
+
+        try {
+            parser.parseCommand("histories");
+            throw new AssertionError("The expected ParseException was not thrown.");
+        } catch (ParseException pe) {
+            assertEquals(MESSAGE_UNKNOWN_COMMAND, pe.getMessage());
+        }
+    }
+
+    @Test
+    public void parseCommand_list() throws Exception {
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_ALIAS) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_ALIAS + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_unrecognisedInput_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        parser.parseCommand("");
+    }
+
+    @Test
+    public void parseCommand_unknownCommand_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(MESSAGE_UNKNOWN_COMMAND);
+        parser.parseCommand("unknownCommand");
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
@@ -35,11 +35,11 @@ import seedu.address.testutil.EntryBuilder;
 import seedu.address.testutil.EntryUtil;
 import seedu.address.ui.ViewMode;
 
-public class EntryBookParserTest {
+public class EntryBookListParserTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    private final EntryBookParser parser = new EntryBookParser();
+    private final EntryBookListParser parser = new EntryBookListParser();
 
     @Test
     public void parseCommand_add() throws Exception {

--- a/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
@@ -15,6 +15,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ArchiveCommand;
+import seedu.address.logic.commands.ArchivesCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -48,6 +50,21 @@ public class EntryBookListParserTest {
         assertEquals(new AddCommand(entry), command);
         AddCommand aliasCommand = (AddCommand) parser.parseCommand(EntryUtil.getAddAliasCommand(entry));
         assertEquals(new AddCommand(entry), aliasCommand);
+    }
+
+    @Test
+    public void parseCommand_archive() throws Exception {
+        ArchiveCommand command = (ArchiveCommand) parser.parseCommand(
+            ArchiveCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new ArchiveCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_archives() throws Exception {
+        assertTrue(parser.parseCommand(ArchivesCommand.COMMAND_WORD) instanceof ArchivesCommand);
+        assertTrue(parser.parseCommand(ArchivesCommand.COMMAND_WORD + " 3") instanceof ArchivesCommand);
+        assertTrue(parser.parseCommand(ArchivesCommand.COMMAND_ALIAS) instanceof ArchivesCommand);
+        assertTrue(parser.parseCommand(ArchivesCommand.COMMAND_ALIAS + " 3") instanceof ArchivesCommand);
     }
 
     @Test

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -232,7 +232,7 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         assertSelectedCardUnchanged();
         assertCommandBoxShowsDefaultStyle();
         assertResultDisplayShowsDefaultStyle();
-        assertStatusBarUnchangedExceptSyncStatus();
+        assertStatusBarUnchangedExceptSyncStatusExcludingCount();
     }
 
     /**
@@ -241,7 +241,7 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
      * 2. Command box has the error style class.<br>
      * 3. Result display box displays {@code expectedResultMessage}.<br>
      * 4. {@code Storage} and {@code EntryListPanel} remain unchanged.<br>
-     * 5. Browser url, selected card and status bar remain unchanged.<br>
+     * 5. Browser url, selected card and status bar excluding count remain unchanged.<br>
      * Verifications 1, 3 and 4 are performed by
      * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
@@ -254,6 +254,6 @@ public class AddCommandSystemTest extends AddressBookSystemTest {
         assertSelectedCardUnchanged();
         assertCommandBoxShowsErrorStyle();
         assertResultDisplayShowsErrorStyle();
-        assertStatusBarUnchanged();
+        assertStatusBarExcludingCountUnchanged();
     }
 }

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -183,6 +183,7 @@ public abstract class AddressBookSystemTest {
         assertEquals(expectedCommandInput, getCommandBox().getInput());
         assertEquals(expectedResultMessage, getResultDisplay().getText());
         assertEquals(new EntryBook(expectedModel.getEntryBook()), testApp.readStorageAddressBook());
+        assertEquals(expectedModel.getContext(), testApp.getModel().getContext());
         assertListMatching(getPersonListPanel(), expectedModel.getFilteredEntryList());
     }
 

--- a/src/test/java/systemtests/AddressBookSystemTest.java
+++ b/src/test/java/systemtests/AddressBookSystemTest.java
@@ -270,7 +270,7 @@ public abstract class AddressBookSystemTest {
     /**
      * Asserts that the entire status bar remains the same.
      */
-    protected void assertStatusBarUnchanged() {
+    protected void assertStatusBarExcludingCountUnchanged() {
         StatusBarFooterHandle handle = getStatusBarFooter();
         assertFalse(handle.isSaveLocationChanged());
         assertFalse(handle.isSyncStatusChanged());
@@ -280,7 +280,7 @@ public abstract class AddressBookSystemTest {
      * Asserts that only the sync status in the status bar was changed to the timing of
      * {@code ClockRule#getInjectedClock()}, while the save location remains the same.
      */
-    protected void assertStatusBarUnchangedExceptSyncStatus() {
+    protected void assertStatusBarUnchangedExceptSyncStatusExcludingCount() {
         StatusBarFooterHandle handle = getStatusBarFooter();
         String timestamp = new Date(clockRule.getInjectedClock().millis()).toString();
         String expectedSyncStatus = String.format(SYNC_STATUS_UPDATED, timestamp);

--- a/src/test/java/systemtests/ClearCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearCommandSystemTest.java
@@ -50,7 +50,7 @@ public class ClearCommandSystemTest extends AddressBookSystemTest {
         assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
         assertCommandBoxShowsDefaultStyle();
         assertResultDisplayShowsDefaultStyle();
-        assertStatusBarUnchangedExceptSyncStatus();
+        assertStatusBarUnchangedExceptSyncStatusExcludingCount();
     }
 
     /**
@@ -58,8 +58,8 @@ public class ClearCommandSystemTest extends AddressBookSystemTest {
      * box displays {@code expectedResultMessage} and the model related components equal to the current model.
      * These verifications are done by
      * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
-     * Also verifies that the browser url, selected card and status bar remain unchanged, and the command box has the
-     * error style.
+     * Also verifies that the browser url, selected card and status bar excluding count remain unchanged,
+     * and the command box has the error style.
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
      */
     private void assertCommandFailure(String command, String expectedResultMessage) {
@@ -70,6 +70,6 @@ public class ClearCommandSystemTest extends AddressBookSystemTest {
         assertSelectedCardUnchanged();
         assertCommandBoxShowsErrorStyle();
         assertResultDisplayShowsErrorStyle();
-        assertStatusBarUnchanged();
+        assertStatusBarExcludingCountUnchanged();
     }
 }

--- a/src/test/java/systemtests/ContextSwitchSystemTest.java
+++ b/src/test/java/systemtests/ContextSwitchSystemTest.java
@@ -55,7 +55,7 @@ public class ContextSwitchSystemTest extends AddressBookSystemTest {
 
     /**
      * Archives the {@code Entry} at the specified {@code index} in {@code model}'s entry book.
-     * @return the removed entry
+     * @return the archived entry
      */
     private Entry archiveEntry(Model model, Index index) {
         Entry targetEntry = getPerson(model, index);
@@ -64,8 +64,8 @@ public class ContextSwitchSystemTest extends AddressBookSystemTest {
     }
 
     /**
-     * Archives the {@code Entry} at the specified {@code index} in {@code model}'s entry book.
-     * @return the removed entry
+     * Un-archives the {@code Entry} at the specified {@code index} in {@code model}'s entry book.
+     * @return the un-archived entry
      */
     private Entry unarchiveEntry(Model model, Index index) {
         Entry targetEntry = getPerson(model, index);
@@ -74,7 +74,7 @@ public class ContextSwitchSystemTest extends AddressBookSystemTest {
     }
 
     /**
-     * Executes the context-switching command that changes the context of model.
+     * Executes the given command.
      * 1. Command box displays an empty string.<br>
      * 2. Command box has the default style class.<br>
      * 3. Result display box displays the success message of executing {@code Command}. <br>

--- a/src/test/java/systemtests/ContextSwitchSystemTest.java
+++ b/src/test/java/systemtests/ContextSwitchSystemTest.java
@@ -1,0 +1,144 @@
+package systemtests;
+
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.testutil.TestUtil.getPerson;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+
+import org.junit.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.ArchiveCommand;
+import seedu.address.logic.commands.ArchivesCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UnarchiveCommand;
+import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
+import seedu.address.model.entry.Entry;
+
+public class ContextSwitchSystemTest extends AddressBookSystemTest {
+
+    @Test
+    public void contextSwitch() {
+
+        /* Case: archive the first entry in the list */
+        Model expectedModel = getModel();
+        String command = ArchiveCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased();
+        Entry archivedEntry = archiveEntry(expectedModel, INDEX_FIRST_ENTRY);
+        String expectedResultMessage = String.format(ArchiveCommand.MESSAGE_ARCHIVE_ENTRY_SUCCESS, archivedEntry);
+        assertCommandSuccess(command, expectedModel, expectedResultMessage);
+
+        /* Case: non-list-context command unarchive fails */
+        command = UnarchiveCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased();
+        expectedResultMessage = String.format(MESSAGE_UNKNOWN_COMMAND);
+        assertCommandFailure(command, expectedResultMessage);
+
+        /* Case: view archives, model should not change */
+        command = ArchivesCommand.COMMAND_WORD;
+        assertArchivesCommandSuccess(command);
+
+        /* Case: unarchive the first entry in the list */
+        expectedModel = getModel();
+        command = UnarchiveCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased();
+        Entry unarchivedEntry = unarchiveEntry(expectedModel, INDEX_FIRST_ENTRY);
+        expectedResultMessage = String.format(UnarchiveCommand.MESSAGE_UNARCHIVE_ENTRY_SUCCESS, unarchivedEntry);
+        assertCommandSuccess(command, expectedModel, expectedResultMessage);
+
+        /* Case: non-archives-context command archive fails */
+        command = ArchiveCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased();
+        expectedResultMessage = String.format(MESSAGE_UNKNOWN_COMMAND);
+        assertCommandFailure(command, expectedResultMessage);
+
+        /* Case: view entry book, model should not change */
+        command = ListCommand.COMMAND_WORD;
+        assertListCommandSuccess(command);
+    }
+
+    /**
+     * Archives the {@code Entry} at the specified {@code index} in {@code model}'s entry book.
+     * @return the removed entry
+     */
+    private Entry archiveEntry(Model model, Index index) {
+        Entry targetEntry = getPerson(model, index);
+        model.archiveEntry(targetEntry);
+        return targetEntry;
+    }
+
+    /**
+     * Archives the {@code Entry} at the specified {@code index} in {@code model}'s entry book.
+     * @return the removed entry
+     */
+    private Entry unarchiveEntry(Model model, Index index) {
+        Entry targetEntry = getPerson(model, index);
+        model.unarchiveEntry(targetEntry);
+        return targetEntry;
+    }
+
+    /**
+     * Executes the context-switching command that changes the context of model.
+     * 1. Command box displays an empty string.<br>
+     * 2. Command box has the default style class.<br>
+     * 3. Result display box displays the success message of executing {@code Command}. <br>
+     * 4. {@code Storage} and {@code EntryListPanel} equal to the corresponding components in
+     * the current model.
+     * 5. Browser url and selected card deselected.<br>
+     * 6. Status bar's sync status excluding count changes.<br>
+     * Verifications 1, 3 and 4 are performed by
+     * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
+     * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     */
+    private void assertCommandSuccess(String command, Model expectedModel, String expectedResultMessage) {
+        executeCommand(command);
+        assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
+        assertSelectedCardDeselected();
+        assertCommandBoxShowsDefaultStyle();
+        assertResultDisplayShowsDefaultStyle();
+        assertStatusBarExcludingCountUnchanged();
+    }
+
+    /**
+     * Asserts that a list command successfully switches context of the Model.
+     * @see ContextSwitchSystemTest#assertCommandSuccess(String, Model, String)
+     */
+    private void assertListCommandSuccess(String command) {
+        Model expectedModel = getModel();
+        expectedModel.setContext(ModelContext.CONTEXT_LIST);
+        String expectedResultMessage = String.format(ListCommand.MESSAGE_SUCCESS);
+
+        assertCommandSuccess(command, expectedModel, expectedResultMessage);
+    }
+
+    /**
+     * Asserts that a archives command successfully switches context of the Model.
+     * @see ContextSwitchSystemTest#assertCommandSuccess(String, Model, String)
+     */
+    private void assertArchivesCommandSuccess(String command) {
+        Model expectedModel = getModel();
+        expectedModel.setContext(ModelContext.CONTEXT_ARCHIVE);
+        String expectedResultMessage = String.format(ArchivesCommand.MESSAGE_SUCCESS);
+
+        assertCommandSuccess(command, expectedModel, expectedResultMessage);
+    }
+
+    /**
+     * Executes {@code command} and asserts that the,<br>
+     * 1. Command box displays {@code command}.<br>
+     * 2. Command box has the error style class.<br>
+     * 3. Result display box displays {@code expectedResultMessage}.<br>
+     * 4. {@code Storage} and {@code EntryListPanel} remain unchanged.<br>
+     * 5. Browser url, selected card and status bar remain unchanged.<br>
+     * Verifications 1, 3 and 4 are performed by
+     * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
+     * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     */
+    private void assertCommandFailure(String command, String expectedResultMessage) {
+        Model expectedModel = getModel();
+
+        executeCommand(command);
+        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);
+        assertSelectedCardUnchanged();
+        assertCommandBoxShowsErrorStyle();
+        assertResultDisplayShowsErrorStyle();
+        assertStatusBarExcludingCountUnchanged();
+    }
+
+}

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -156,14 +156,14 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
 
         assertCommandBoxShowsDefaultStyle();
         assertResultDisplayShowsDefaultStyle();
-        assertStatusBarUnchangedExceptSyncStatus();
+        assertStatusBarUnchangedExceptSyncStatusExcludingCount();
     }
 
     /**
      * Executes {@code command} and in addition,<br>
      * 1. Asserts that the command box displays {@code command}.<br>
      * 2. Asserts that result display box displays {@code expectedResultMessage}.<br>
-     * 3. Asserts that the browser url, selected card and status bar remain unchanged.<br>
+     * 3. Asserts that the browser url, selected card and status bar excluding count remain unchanged.<br>
      * 4. Asserts that the command box has the error style.<br>
      * Verifications 1 and 2 are performed by
      * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
@@ -177,6 +177,6 @@ public class DeleteCommandSystemTest extends AddressBookSystemTest {
         assertSelectedCardUnchanged();
         assertCommandBoxShowsErrorStyle();
         assertResultDisplayShowsErrorStyle();
-        assertStatusBarUnchanged();
+        assertStatusBarExcludingCountUnchanged();
     }
 }

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -268,14 +268,14 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         } else {
             assertSelectedCardUnchanged();
         }
-        assertStatusBarUnchangedExceptSyncStatus();
+        assertStatusBarUnchangedExceptSyncStatusExcludingCount();
     }
 
     /**
      * Executes {@code command} and in addition,<br>
      * 1. Asserts that the command box displays {@code command}.<br>
      * 2. Asserts that result display box displays {@code expectedResultMessage}.<br>
-     * 3. Asserts that the browser url, selected card and status bar remain unchanged.<br>
+     * 3. Asserts that the browser url, selected card and status bar excluding count remain unchanged.<br>
      * 4. Asserts that the command box has the error style.<br>
      * Verifications 1 and 2 are performed by
      * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
@@ -289,6 +289,6 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         assertSelectedCardUnchanged();
         assertCommandBoxShowsErrorStyle();
         assertResultDisplayShowsErrorStyle();
-        assertStatusBarUnchanged();
+        assertStatusBarExcludingCountUnchanged();
     }
 }

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -148,8 +148,9 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
      * and the model related components equal to {@code expectedModel}.
      * These verifications are done by
      * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
-     * Also verifies that the status bar excluding count remains unchanged, and the command box has the default style class, and the
-     * selected card updated accordingly, depending on {@code cardStatus}.
+     * Also verifies that the status bar excluding count remains unchanged,
+     * and the command box has the default style class,
+     * and the selected card updated accordingly, depending on {@code cardStatus}.
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
      */
     private void assertCommandSuccess(String command, Model expectedModel) {

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -148,7 +148,7 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
      * and the model related components equal to {@code expectedModel}.
      * These verifications are done by
      * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
-     * Also verifies that the status bar remains unchanged, and the command box has the default style class, and the
+     * Also verifies that the status bar excluding count remains unchanged, and the command box has the default style class, and the
      * selected card updated accordingly, depending on {@code cardStatus}.
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
      */
@@ -160,7 +160,7 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
         assertCommandBoxShowsDefaultStyle();
         assertResultDisplayShowsDefaultStyle();
-        assertStatusBarUnchanged();
+        assertStatusBarExcludingCountUnchanged();
     }
 
     /**
@@ -168,8 +168,8 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
      * box displays {@code expectedResultMessage} and the model related components equal to the current model.
      * These verifications are done by
      * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
-     * Also verifies that the browser url, selected card and status bar remain unchanged, and the command box has the
-     * error style.
+     * Also verifies that the browser url, selected card and status bar excluding count remain unchanged,
+     * and the command box has the error style.
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
      */
     private void assertCommandFailure(String command, String expectedResultMessage) {
@@ -180,6 +180,6 @@ public class FindCommandSystemTest extends AddressBookSystemTest {
         assertSelectedCardUnchanged();
         assertCommandBoxShowsErrorStyle();
         assertResultDisplayShowsErrorStyle();
-        assertStatusBarUnchanged();
+        assertStatusBarExcludingCountUnchanged();
     }
 }

--- a/src/test/java/systemtests/SelectCommandSystemTest.java
+++ b/src/test/java/systemtests/SelectCommandSystemTest.java
@@ -94,7 +94,7 @@ public class SelectCommandSystemTest extends AddressBookSystemTest {
      * {@code expectedSelectedCardIndex} of the selected entry.<br>
      * 4. {@code Storage} and {@code EntryListPanel} remain unchanged.<br>
      * 5. Selected card is at {@code expectedSelectedCardIndex} and the browser url is updated accordingly.<br>
-     * 6. Status bar remains unchanged.<br>
+     * 6. Status bar excluding count remains unchanged.<br>
      * Verifications 1, 3 and 4 are performed by
      * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
@@ -117,7 +117,7 @@ public class SelectCommandSystemTest extends AddressBookSystemTest {
 
         assertCommandBoxShowsDefaultStyle();
         assertResultDisplayShowsDefaultStyle();
-        assertStatusBarUnchanged();
+        assertStatusBarExcludingCountUnchanged();
     }
 
     /**
@@ -126,7 +126,7 @@ public class SelectCommandSystemTest extends AddressBookSystemTest {
      * 2. Command box has the error style class.<br>
      * 3. Result display box displays {@code expectedResultMessage}.<br>
      * 4. {@code Storage} and {@code EntryListPanel} remain unchanged.<br>
-     * 5. Browser url, selected card and status bar remain unchanged.<br>
+     * 5. Browser url, selected card and status bar excluding count remain unchanged.<br>
      * Verifications 1, 3 and 4 are performed by
      * {@code AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
      * @see AddressBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
@@ -139,6 +139,6 @@ public class SelectCommandSystemTest extends AddressBookSystemTest {
         assertSelectedCardUnchanged();
         assertCommandBoxShowsErrorStyle();
         assertResultDisplayShowsErrorStyle();
-        assertStatusBarUnchanged();
+        assertStatusBarExcludingCountUnchanged();
     }
 }


### PR DESCRIPTION
Resolves part of #69 and #70.

#### Summary of changes
* Add stubs for future archive and unarchive commands
* Implement context-swinging to support future feed-listing and archiving features
  * Model is now tied to a ```ModelContext```
  * Only allows a limited set of commands (out of all available commands in the app) per context
  * User can switch contexts by calling the context-switching commands