### PR TITLE
View articles offline if available

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.logging.Logger;
 
@@ -119,9 +120,10 @@ public class AddCommand extends Command {
 
             // Download article content to local storage
             byte[] articleContent = Network.fetchAsBytes(urlString);
-            model.addArticle(urlString, articleContent);
-
-            offlineLink = Optional.of(new Link(model.getStorage().getArticlePath(urlString).toUri().toASCIIString()));
+            Optional<Path> articlePath = model.addArticle(urlString, articleContent);
+            if (articlePath.isPresent()) {
+                offlineLink = Optional.of(new Link(articlePath.get().toUri().toASCIIString()));
+            }
 
             if (noTitleOrNoDescription) {
 

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -29,6 +29,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.entry.Description;
 import seedu.address.model.entry.Entry;
+import seedu.address.model.entry.Link;
 import seedu.address.model.entry.Title;
 import seedu.address.model.util.Candidate;
 import seedu.address.network.Network;
@@ -112,11 +113,15 @@ public class AddCommand extends Command {
             }
         }
 
+        Optional<Link> offlineLink = Optional.empty();
+
         try {
 
             // Download article content to local storage
             byte[] articleContent = Network.fetchAsBytes(urlString);
             model.addArticle(urlString, articleContent);
+
+            offlineLink = Optional.of(new Link(model.getStorage().getArticlePath(urlString).toUri().toASCIIString()));
 
             if (noTitleOrNoDescription) {
 
@@ -150,6 +155,7 @@ public class AddCommand extends Command {
                 title.isEmpty() ? candidateTitle.get() : title, // replace title if empty
                 description.isEmpty() ? candidateDescription.get() : description, // replace description if empty
                 toAdd.getLink(),
+                offlineLink,
                 toAdd.getAddress(),
                 toAdd.getTags()
         );

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -2,6 +2,7 @@ package seedu.address.model;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javafx.beans.property.ReadOnlyProperty;
@@ -101,7 +102,7 @@ public interface Model {
      */
     void clearEntryBook();
 
-    void addArticle(String url, byte[] articleContent) throws IOException;
+    Optional<Path> addArticle(String url, byte[] articleContent) throws IOException;
 
     /** Returns an unmodifiable view of the filtered entry list */
     ObservableList<Entry> getFilteredEntryList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -160,8 +161,8 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void addArticle(String url, byte[] articleContent) throws IOException {
-        storage.addArticle(url, articleContent);
+    public Optional<Path> addArticle(String url, byte[] articleContent) throws IOException {
+        return storage.addArticle(url, articleContent);
     }
 
     //=========== Filtered Entry List Accessors =============================================================

--- a/src/main/java/seedu/address/model/entry/Entry.java
+++ b/src/main/java/seedu/address/model/entry/Entry.java
@@ -42,12 +42,12 @@ public class Entry {
     /**
      * Every field must be present and not null.
      */
-    public Entry(Title title, Description description, Link link, Link offlineLink, Address address, Set<Tag> tags) {
+    public Entry(Title title, Description description, Link link, Optional<Link> offlineLink, Address address, Set<Tag> tags) {
         requireAllNonNull(title, description, link, address, tags);
         this.title = title;
         this.description = description;
         this.link = link;
-        this.offlineLink = Optional.of(offlineLink);
+        this.offlineLink = offlineLink;
         this.address = address;
         this.tags.addAll(tags);
     }
@@ -66,6 +66,10 @@ public class Entry {
 
     public Optional<Link> getOfflineLink() {
         return offlineLink;
+    }
+
+    public Link getOfflineOrOriginalLink() {
+        return offlineLink.orElse(link);
     }
 
     public Address getAddress() {

--- a/src/main/java/seedu/address/model/entry/Entry.java
+++ b/src/main/java/seedu/address/model/entry/Entry.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.model.tag.Tag;
@@ -23,6 +24,7 @@ public class Entry {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
+    private final Optional<Link> offlineLink;
 
     /**
      * Every field must be present and not null.
@@ -32,6 +34,20 @@ public class Entry {
         this.title = title;
         this.description = description;
         this.link = link;
+        this.offlineLink = Optional.empty();
+        this.address = address;
+        this.tags.addAll(tags);
+    }
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Entry(Title title, Description description, Link link, Link offlineLink, Address address, Set<Tag> tags) {
+        requireAllNonNull(title, description, link, address, tags);
+        this.title = title;
+        this.description = description;
+        this.link = link;
+        this.offlineLink = Optional.of(offlineLink);
         this.address = address;
         this.tags.addAll(tags);
     }
@@ -46,6 +62,10 @@ public class Entry {
 
     public Link getLink() {
         return link;
+    }
+
+    public Optional<Link> getOfflineLink() {
+        return offlineLink;
     }
 
     public Address getAddress() {
@@ -108,8 +128,12 @@ public class Entry {
                 .append(" Description: ")
                 .append(getDescription())
                 .append(" Link: ")
-                .append(getLink())
-                .append(" Address: ")
+                .append(getLink());
+        offlineLink.ifPresent(link1 ->
+            builder.append(" Offline link: ")
+                    .append(link1)
+        );
+        builder.append(" Address: ")
                 .append(getAddress())
                 .append(" Tags: ");
         getTags().forEach(builder::append);

--- a/src/main/java/seedu/address/model/entry/Entry.java
+++ b/src/main/java/seedu/address/model/entry/Entry.java
@@ -42,7 +42,9 @@ public class Entry {
     /**
      * Every field must be present and not null.
      */
-    public Entry(Title title, Description description, Link link, Optional<Link> offlineLink, Address address, Set<Tag> tags) {
+    public Entry(Title title, Description description,
+                 Link link, Optional<Link> offlineLink,
+                 Address address, Set<Tag> tags) {
         requireAllNonNull(title, description, link, address, tags);
         this.title = title;
         this.description = description;

--- a/src/main/java/seedu/address/storage/ArticleStorage.java
+++ b/src/main/java/seedu/address/storage/ArticleStorage.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Optional;
 
 /**
  * Represents a storage for articles.
@@ -19,7 +20,7 @@ public interface ArticleStorage {
      * @param url cannot be null.
      * @throws IOException if there was any problem writing to the file.
      */
-    void addArticle(String url, byte[] articleContent) throws IOException;
+    Optional<Path> addArticle(String url, byte[] articleContent) throws IOException;
 
     /**
      * Converts a given url to a Path where the article would be stored.

--- a/src/main/java/seedu/address/storage/DataDirectoryArticleStorage.java
+++ b/src/main/java/seedu/address/storage/DataDirectoryArticleStorage.java
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
 import java.util.logging.Logger;
 
 import org.apache.commons.codec.binary.Base32;
@@ -30,13 +31,15 @@ public class DataDirectoryArticleStorage implements ArticleStorage {
     }
 
     @Override
-    public void addArticle(String url, byte[] articleContent) throws IOException {
+    public Optional<Path> addArticle(String url, byte[] articleContent) throws IOException {
         Path targetPath = getArticlePath(url);
 
         // Ensure data directory exists
         FileUtil.createDirectory(directoryPath);
 
         FileUtil.writeToFile(targetPath, articleContent);
+
+        return Optional.of(targetPath);
     }
 
     /**

--- a/src/main/java/seedu/address/storage/DataDirectoryArticleStorage.java
+++ b/src/main/java/seedu/address/storage/DataDirectoryArticleStorage.java
@@ -52,7 +52,7 @@ public class DataDirectoryArticleStorage implements ArticleStorage {
             byte[] truncatedHash = new byte[16];
             System.arraycopy(encodedHash, 0, truncatedHash, 0, 16);
             byte[] hashInBase32 = new Base32().encode(truncatedHash);
-            return new String(hashInBase32, StandardCharsets.UTF_8);
+            return new String(hashInBase32, StandardCharsets.UTF_8) + ".html";
         } catch (NoSuchAlgorithmException nsae) {
             logger.severe("SHA-256 hash not supported on this system. Saving links cannot be done");
             throw nsae;

--- a/src/main/java/seedu/address/storage/JsonAdaptedEntry.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedEntry.java
@@ -104,7 +104,7 @@ class JsonAdaptedEntry {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Link.class.getSimpleName()));
         }
         if (!offlineLink.isEmpty() && !Link.isValidConstructionLink(offlineLink)) {
-            throw new IllegalValueException(Link.formExceptionMessage(link));
+            throw new IllegalValueException(Link.formExceptionMessage(offlineLink));
         }
         final Optional<Link> modelOfflineLink =
                 offlineLink.isEmpty()

--- a/src/main/java/seedu/address/storage/JsonAdaptedEntry.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedEntry.java
@@ -24,9 +24,9 @@ class JsonAdaptedEntry {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Entry's %s field is missing!";
 
-    private final String name;
-    private final String phone;
-    private final String email;
+    private final String title;
+    private final String description;
+    private final String link;
     private final String address;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
@@ -34,12 +34,12 @@ class JsonAdaptedEntry {
      * Constructs a {@code JsonAdaptedEntry} with the given entry details.
      */
     @JsonCreator
-    public JsonAdaptedEntry(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
-                            @JsonProperty("email") String email, @JsonProperty("address") String address,
+    public JsonAdaptedEntry(@JsonProperty("title") String title, @JsonProperty("description") String description,
+                            @JsonProperty("link") String link, @JsonProperty("address") String address,
                             @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
-        this.name = name;
-        this.phone = phone;
-        this.email = email;
+        this.title = title;
+        this.description = description;
+        this.link = link;
         this.address = address;
         if (tagged != null) {
             this.tagged.addAll(tagged);
@@ -50,9 +50,9 @@ class JsonAdaptedEntry {
      * Converts a given {@code Entry} into this class for Jackson use.
      */
     public JsonAdaptedEntry(Entry source) {
-        name = source.getTitle().fullTitle;
-        phone = source.getDescription().value;
-        email = source.getLink().value;
+        title = source.getTitle().fullTitle;
+        description = source.getDescription().value;
+        link = source.getLink().value;
         address = source.getAddress().value;
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
@@ -70,30 +70,30 @@ class JsonAdaptedEntry {
             personTags.add(tag.toModelType());
         }
 
-        if (name == null) {
+        if (title == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Title.class.getSimpleName()));
         }
-        if (!Title.isValidConstructionTitle(name)) {
-            throw new IllegalValueException(Title.formExceptionMessage(name));
+        if (!Title.isValidConstructionTitle(title)) {
+            throw new IllegalValueException(Title.formExceptionMessage(title));
         }
-        final Title modelTitle = new Title(name);
+        final Title modelTitle = new Title(title);
 
-        if (phone == null) {
+        if (description == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                                                           Description.class.getSimpleName()));
         }
-        if (!Description.isValidConstructionDescription(phone)) {
-            throw new IllegalValueException(Description.formExceptionMessage(phone));
+        if (!Description.isValidConstructionDescription(description)) {
+            throw new IllegalValueException(Description.formExceptionMessage(description));
         }
-        final Description modelDescription = new Description(phone);
+        final Description modelDescription = new Description(description);
 
-        if (email == null) {
+        if (link == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Link.class.getSimpleName()));
         }
-        if (!Link.isValidConstructionLink(email)) {
-            throw new IllegalValueException(Link.formExceptionMessage(email));
+        if (!Link.isValidConstructionLink(link)) {
+            throw new IllegalValueException(Link.formExceptionMessage(link));
         }
-        final Link modelLink = new Link(email);
+        final Link modelLink = new Link(link);
 
         if (address == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));

--- a/src/main/java/seedu/address/storage/JsonAdaptedEntry.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedEntry.java
@@ -3,6 +3,7 @@ package seedu.address.storage;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -27,6 +28,7 @@ class JsonAdaptedEntry {
     private final String title;
     private final String description;
     private final String link;
+    private final String offlineLink;
     private final String address;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
 
@@ -35,11 +37,13 @@ class JsonAdaptedEntry {
      */
     @JsonCreator
     public JsonAdaptedEntry(@JsonProperty("title") String title, @JsonProperty("description") String description,
-                            @JsonProperty("link") String link, @JsonProperty("address") String address,
+                            @JsonProperty("link") String link, @JsonProperty("offlineLink") String offlineLink,
+                            @JsonProperty("address") String address,
                             @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
         this.title = title;
         this.description = description;
         this.link = link;
+        this.offlineLink = offlineLink;
         this.address = address;
         if (tagged != null) {
             this.tagged.addAll(tagged);
@@ -53,6 +57,7 @@ class JsonAdaptedEntry {
         title = source.getTitle().fullTitle;
         description = source.getDescription().value;
         link = source.getLink().value;
+        offlineLink = source.getOfflineLink().isPresent() ? source.getOfflineLink().get().value : "";
         address = source.getAddress().value;
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
@@ -95,6 +100,17 @@ class JsonAdaptedEntry {
         }
         final Link modelLink = new Link(link);
 
+        if (offlineLink == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Link.class.getSimpleName()));
+        }
+        if (!offlineLink.isEmpty() && !Link.isValidConstructionLink(offlineLink)) {
+            throw new IllegalValueException(Link.formExceptionMessage(link));
+        }
+        final Optional<Link> modelOfflineLink =
+                offlineLink.isEmpty()
+                        ? Optional.empty()
+                        : Optional.of(new Link(offlineLink));
+
         if (address == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName()));
         }
@@ -104,7 +120,7 @@ class JsonAdaptedEntry {
         final Address modelAddress = new Address(address);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Entry(modelTitle, modelDescription, modelLink, modelAddress, modelTags);
+        return new Entry(modelTitle, modelDescription, modelLink, modelOfflineLink, modelAddress, modelTags);
     }
 
 }

--- a/src/main/java/seedu/address/storage/Storage.java
+++ b/src/main/java/seedu/address/storage/Storage.java
@@ -30,6 +30,6 @@ public interface Storage extends EntryBookStorage, UserPrefsStorage, ArticleStor
     void saveAddressBook(ReadOnlyEntryBook addressBook) throws IOException;
 
     @Override
-    void addArticle(String url, byte[] articleContent) throws IOException;
+    Optional<Path> addArticle(String url, byte[] articleContent) throws IOException;
 
 }

--- a/src/main/java/seedu/address/storage/StorageManager.java
+++ b/src/main/java/seedu/address/storage/StorageManager.java
@@ -87,8 +87,8 @@ public class StorageManager implements Storage {
     }
 
     @Override
-    public void addArticle(String url, byte[] content) throws IOException {
-        articleStorage.addArticle(url, content);
+    public Optional<Path> addArticle(String url, byte[] content) throws IOException {
+        return articleStorage.addArticle(url, content);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/BrowserPanel.java
+++ b/src/main/java/seedu/address/ui/BrowserPanel.java
@@ -155,7 +155,7 @@ public class BrowserPanel extends UiPart<Region> {
      * @param entry entry to load
      */
     private void loadEntryPage(Entry entry) {
-        loadPage(entry.getLink().value);
+        loadPage(entry.getOfflineOrOriginalLink().value);
     }
 
     /**

--- a/src/test/data/JsonEntryBookStorageTest/invalidAndValidEntryEntryBook.json
+++ b/src/test/data/JsonEntryBookStorageTest/invalidAndValidEntryEntryBook.json
@@ -1,13 +1,15 @@
 {
   "persons": [ {
-    "name": "Valid Title!",
-    "phone": "Val1d-C@mment! ~ !",
-    "email": "https://hans.example.com",
+    "title": "Valid Title!",
+    "description": "Val1d-C@mment! ~ !",
+    "link": "https://hans.example.com",
+    "offlineLink": "",
     "address": "4th street"
   }, {
-    "name": "Entry With Invalid Link Field",
-    "phone": "Oh no!",
-    "email": "hans@example.com",
+    "title": "Entry With Invalid Link Field",
+    "description": "Oh no!",
+    "link": "hans@example.com",
+    "offlineLink": "",
     "address": "4th street"
   } ]
 }

--- a/src/test/data/JsonEntryBookStorageTest/invalidEntryEntryBook.json
+++ b/src/test/data/JsonEntryBookStorageTest/invalidEntryEntryBook.json
@@ -1,8 +1,9 @@
 {
   "persons": [ {
-    "name": "Entry with invalid link field",
-    "phone": "Oh no!",
-    "email": "hans@example.com",
+    "title": "Entry with invalid link field",
+    "description": "Oh no!",
+    "link": "hans@example.com",
+    "offlineLink": "",
     "address": "4th street"
   } ]
 }

--- a/src/test/data/JsonSerializableEntryBookTest/duplicateEntryEntryBook.json
+++ b/src/test/data/JsonSerializableEntryBookTest/duplicateEntryEntryBook.json
@@ -1,14 +1,16 @@
 {
   "persons": [ {
-    "name": "Alice Pauline",
-    "phone": "Comment1",
-    "email": "https://alice.example.com",
+    "title": "Alice Pauline",
+    "description": "Comment1",
+    "link": "https://alice.example.com",
+    "offlineLink": "",
     "address": "123, Jurong West Ave 6, #08-111",
     "tagged": [ "friends" ]
   }, {
-    "name": "Alice Pauline",
-    "phone": "Comment2",
-    "email": "https://alice.example.com",
+    "title": "Alice Pauline",
+    "description": "Comment2",
+    "link": "https://alice.example.com",
+    "offlineLink": "",
     "address": "4th street"
   } ]
 }

--- a/src/test/data/JsonSerializableEntryBookTest/invalidEntryEntryBook.json
+++ b/src/test/data/JsonSerializableEntryBookTest/invalidEntryEntryBook.json
@@ -1,8 +1,9 @@
 {
   "persons": [ {
-    "name": "Hans Muster",
-    "phone": "9482424",
-    "email": "invalid@email!3e",
+    "title": "Hans Muster",
+    "description": "9482424",
+    "link": "invalid@email!3e",
+    "offlineLink": "",
     "address": "4th street"
   } ]
 }

--- a/src/test/data/JsonSerializableEntryBookTest/typicalEntryEntryBook.json
+++ b/src/test/data/JsonSerializableEntryBookTest/typicalEntryEntryBook.json
@@ -1,45 +1,52 @@
 {
   "_comment": "AddressBook save file which contains the same Person values as in TypicalPersons#getTypicalAddressBook()",
   "persons" : [ {
-    "name" : "Alice Pauline",
-    "phone" : "Description place-holder",
-    "email" : "https://alice.example.com",
+    "title" : "Alice Pauline",
+    "description" : "Description place-holder",
+    "link" : "https://alice.example.com",
+    "offlineLink" : "",
     "address" : "123, Jurong West Ave 6, #08-111",
     "tagged" : [ "friends" ]
   }, {
-    "name" : "Benson Meier",
-    "phone" : "Description place-holder",
-    "email" : "https://johnd.example.com",
+    "title" : "Benson Meier",
+    "description" : "Description place-holder",
+    "link" : "https://johnd.example.com",
+    "offlineLink" : "",
     "address" : "311, Clementi Ave 2, #02-25",
     "tagged" : [ "owesMoney", "friends" ]
   }, {
-    "name" : "Carl Kurz",
-    "phone" : "Description place-holder",
-    "email" : "https://heinz.example.com",
+    "title" : "Carl Kurz",
+    "description" : "Description place-holder",
+    "link" : "https://heinz.example.com",
+    "offlineLink" : "",
     "address" : "wall street",
     "tagged" : [ ]
   }, {
-    "name" : "Daniel Meier",
-    "phone" : "Description place-holder",
-    "email" : "https://cornelia.example.com",
+    "title" : "Daniel Meier",
+    "description" : "Description place-holder",
+    "link" : "https://cornelia.example.com",
+    "offlineLink" : "",
     "address" : "10th street",
     "tagged" : [ "friends" ]
   }, {
-    "name" : "Elle Meyer",
-    "phone" : "Description place-holder",
-    "email" : "https://werner.example.com",
+    "title" : "Elle Meyer",
+    "description" : "Description place-holder",
+    "link" : "https://werner.example.com",
+    "offlineLink" : "",
     "address" : "michegan ave",
     "tagged" : [ ]
   }, {
-    "name" : "Fiona Kunz",
-    "phone" : "Description place-holder",
-    "email" : "https://lydia.example.com",
+    "title" : "Fiona Kunz",
+    "description" : "Description place-holder",
+    "link" : "https://lydia.example.com",
+    "offlineLink" : "",
     "address" : "little tokyo",
     "tagged" : [ ]
   }, {
-    "name" : "George Best",
-    "phone" : "Description place-holder",
-    "email" : "https://anna.example.com",
+    "title" : "George Best",
+    "description" : "Description place-holder",
+    "link" : "https://anna.example.com",
+    "offlineLink" : "",
     "address" : "4th street",
     "tagged" : [ ]
   } ]

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -27,6 +27,7 @@ import static seedu.address.testutil.TypicalEntries.STUB_LINK_NO_TITLE_NO_DESCRI
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.Rule;
@@ -196,7 +197,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void addArticle(String url, byte[] articleContent) {
+        public Optional<Path> addArticle(String url, byte[] articleContent) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -386,8 +387,8 @@ public class AddCommandTest {
         private final ArrayList<Entry> entriesAdded = new ArrayList<>();
 
         @Override
-        public void addArticle(String url, byte[] articleContent) {
-            // stub - empty on purpose
+        public Optional<Path> addArticle(String url, byte[] articleContent) {
+            return Optional.empty();
         }
 
         @Override

--- a/src/test/java/seedu/address/mocks/StorageStub.java
+++ b/src/test/java/seedu/address/mocks/StorageStub.java
@@ -59,8 +59,8 @@ public class StorageStub implements Storage {
     }
 
     @Override
-    public void addArticle(String url, byte[] content) {
-        // Do nothing
+    public Optional<Path> addArticle(String url, byte[] content) {
+        return Optional.empty();
     }
 
     @Override

--- a/src/test/java/seedu/address/storage/JsonAdaptedEntryTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedEntryTest.java
@@ -22,11 +22,13 @@ public class JsonAdaptedEntryTest {
     private static final String INVALID_DESCRIPTION = " ";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_LINK = "example.com";
+    private static final String INVALID_OFFLINE_LINK = "example.com";
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_TITLE = BENSON.getTitle().toString();
     private static final String VALID_DESCRIPTION = BENSON.getDescription().toString();
     private static final String VALID_LINK = BENSON.getLink().toString();
+    private static final String VALID_OFFLINE_LINK = "";
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
@@ -41,14 +43,26 @@ public class JsonAdaptedEntryTest {
     @Test
     public void toModelType_invalidTitle_throwsIllegalValueException() {
         JsonAdaptedEntry entry =
-                new JsonAdaptedEntry(INVALID_TITLE, VALID_DESCRIPTION, VALID_LINK, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedEntry(
+                        INVALID_TITLE,
+                        VALID_DESCRIPTION,
+                        VALID_LINK,
+                        VALID_OFFLINE_LINK,
+                        VALID_ADDRESS,
+                        VALID_TAGS);
         String expectedMessage = Title.formExceptionMessage(INVALID_TITLE);
         Assert.assertThrows(IllegalValueException.class, expectedMessage, entry::toModelType);
     }
 
     @Test
     public void toModelType_nullTitle_throwsIllegalValueException() {
-        JsonAdaptedEntry entry = new JsonAdaptedEntry(null, VALID_DESCRIPTION, VALID_LINK, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedEntry entry = new JsonAdaptedEntry(
+                null,
+                VALID_DESCRIPTION,
+                VALID_LINK,
+                VALID_OFFLINE_LINK,
+                VALID_ADDRESS,
+                VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Title.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, entry::toModelType);
     }
@@ -56,14 +70,24 @@ public class JsonAdaptedEntryTest {
     @Test
     public void toModelType_invalidDescription_throwsIllegalValueException() {
         JsonAdaptedEntry entry =
-            new JsonAdaptedEntry(VALID_TITLE, INVALID_DESCRIPTION, VALID_LINK, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedEntry(VALID_TITLE,
+                        INVALID_DESCRIPTION,
+                        VALID_LINK,
+                        VALID_OFFLINE_LINK,
+                        VALID_ADDRESS,
+                        VALID_TAGS);
         String expectedMessage = Description.formExceptionMessage(INVALID_DESCRIPTION);
         Assert.assertThrows(IllegalValueException.class, expectedMessage, entry::toModelType);
     }
 
     @Test
     public void toModelType_nullDescription_throwsIllegalValueException() {
-        JsonAdaptedEntry entry = new JsonAdaptedEntry(VALID_TITLE, null, VALID_LINK, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedEntry entry = new JsonAdaptedEntry(VALID_TITLE,
+                null,
+                VALID_LINK,
+                VALID_OFFLINE_LINK,
+                VALID_ADDRESS,
+                VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Description.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, entry::toModelType);
     }
@@ -71,14 +95,49 @@ public class JsonAdaptedEntryTest {
     @Test
     public void toModelType_invalidLink_throwsIllegalValueException() {
         JsonAdaptedEntry entry =
-                new JsonAdaptedEntry(VALID_TITLE, VALID_DESCRIPTION, INVALID_LINK, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedEntry(VALID_TITLE,
+                        VALID_DESCRIPTION,
+                        INVALID_LINK,
+                        VALID_OFFLINE_LINK,
+                        VALID_ADDRESS,
+                        VALID_TAGS);
         String expectedMessage = Link.formExceptionMessage(INVALID_LINK);
         Assert.assertThrows(IllegalValueException.class, expectedMessage, entry::toModelType);
     }
 
     @Test
     public void toModelType_nullLink_throwsIllegalValueException() {
-        JsonAdaptedEntry entry = new JsonAdaptedEntry(VALID_TITLE, VALID_DESCRIPTION, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedEntry entry = new JsonAdaptedEntry(VALID_TITLE,
+                VALID_DESCRIPTION,
+                null,
+                VALID_OFFLINE_LINK,
+                VALID_ADDRESS,
+                VALID_TAGS);
+        String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Link.class.getSimpleName());
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, entry::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidOfflineLink_throwsIllegalValueException() {
+        JsonAdaptedEntry entry =
+                new JsonAdaptedEntry(VALID_TITLE,
+                        VALID_DESCRIPTION,
+                        VALID_LINK,
+                        INVALID_OFFLINE_LINK,
+                        VALID_ADDRESS,
+                        VALID_TAGS);
+        String expectedMessage = Link.formExceptionMessage(INVALID_OFFLINE_LINK);
+        Assert.assertThrows(IllegalValueException.class, expectedMessage, entry::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullOfflineLink_throwsIllegalValueException() {
+        JsonAdaptedEntry entry = new JsonAdaptedEntry(VALID_TITLE,
+                VALID_DESCRIPTION,
+                VALID_LINK,
+                null,
+                VALID_ADDRESS,
+                VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Link.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, entry::toModelType);
     }
@@ -86,14 +145,24 @@ public class JsonAdaptedEntryTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedEntry entry =
-                new JsonAdaptedEntry(VALID_TITLE, VALID_DESCRIPTION, VALID_LINK, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedEntry(VALID_TITLE,
+                        VALID_DESCRIPTION,
+                        VALID_LINK,
+                        VALID_OFFLINE_LINK,
+                        INVALID_ADDRESS,
+                        VALID_TAGS);
         String expectedMessage = Address.formExceptionMessage(INVALID_ADDRESS);
         Assert.assertThrows(IllegalValueException.class, expectedMessage, entry::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedEntry entry = new JsonAdaptedEntry(VALID_TITLE, VALID_DESCRIPTION, VALID_LINK, null, VALID_TAGS);
+        JsonAdaptedEntry entry = new JsonAdaptedEntry(VALID_TITLE,
+                VALID_DESCRIPTION,
+                VALID_LINK,
+                VALID_OFFLINE_LINK,
+                null,
+                VALID_TAGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, entry::toModelType);
     }
@@ -103,7 +172,12 @@ public class JsonAdaptedEntryTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedEntry entry =
-                new JsonAdaptedEntry(VALID_TITLE, VALID_DESCRIPTION, VALID_LINK, VALID_ADDRESS, invalidTags);
+                new JsonAdaptedEntry(VALID_TITLE,
+                        VALID_DESCRIPTION,
+                        VALID_LINK,
+                        VALID_OFFLINE_LINK,
+                        VALID_ADDRESS,
+                        invalidTags);
         Assert.assertThrows(IllegalValueException.class, entry::toModelType);
     }
 


### PR DESCRIPTION
Resolves #52 and #54.
Resolves part of #19.

Adds `offlineLink` field to `Entry`, and `BrowserPanel` views `offlineLink` if it exists.

### Summary of changes

* Add `offlineLink` to `Entry`
* Connect `offlineLink` to `BrowserPanel`
* Update `JsonAdaptedEntry` so that `offlineLink` will be saved to disk
* Adds `.html` extension to local filenames so that `WebEngine` views them properly.