### PR TITLE
Offline mode: Resolve links to absolute form when adding articles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ dependencies {
     String jUnitVersion = '5.1.0'
 
     compile group: 'com.github.chimbori', name:'crux', version: '2.0.2'
+    compile group: 'net.sourceforge.cssparser', name: 'cssparser', version: '0.9.27'
 
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.7.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.7.4'

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -33,6 +33,7 @@ import seedu.address.model.entry.Entry;
 import seedu.address.model.entry.Link;
 import seedu.address.model.entry.Title;
 import seedu.address.model.util.Candidate;
+import seedu.address.util.AbsoluteUrlDocumentConverter;
 import seedu.address.util.Network;
 
 /**
@@ -120,7 +121,11 @@ public class AddCommand extends Command {
 
             // Download article content to local storage
             byte[] articleContent = Network.fetchAsBytes(urlString);
-            Optional<Path> articlePath = model.addArticle(urlString, articleContent);
+            // Convert all links in article to absolute links
+            byte[] absoluteLinkedArticleContent = AbsoluteUrlDocumentConverter.convert(
+                    new URL(urlString),
+                    articleContent);
+            Optional<Path> articlePath = model.addArticle(urlString, absoluteLinkedArticleContent);
             if (articlePath.isPresent()) {
                 offlineLink = Optional.of(new Link(articlePath.get().toUri().toASCIIString()));
             }

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -33,7 +33,7 @@ import seedu.address.model.entry.Entry;
 import seedu.address.model.entry.Link;
 import seedu.address.model.entry.Title;
 import seedu.address.model.util.Candidate;
-import seedu.address.network.Network;
+import seedu.address.util.Network;
 
 /**
  * Adds a entry to the address book.

--- a/src/main/java/seedu/address/logic/commands/FeedCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FeedCommand.java
@@ -25,7 +25,7 @@ import seedu.address.model.entry.Description;
 import seedu.address.model.entry.Entry;
 import seedu.address.model.entry.Link;
 import seedu.address.model.entry.Title;
-import seedu.address.network.Network;
+import seedu.address.util.Network;
 
 /**
  * Shows a feed given an URL.

--- a/src/main/java/seedu/address/util/AbsoluteUrlDocumentConverter.java
+++ b/src/main/java/seedu/address/util/AbsoluteUrlDocumentConverter.java
@@ -1,0 +1,59 @@
+package seedu.address.util;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+/**
+ * Converts all the urls in a document to its absolute equivalent,
+ * so it can be saved on disk and used again later.
+ */
+public abstract class AbsoluteUrlDocumentConverter {
+
+    /**
+     * Converts all the urls in a document to its absolute equivalent,
+     * so it can be saved on disk and used again later.
+     */
+    public static byte[] convert(URL baseUrl, byte[] articleContent) {
+        Document document = Jsoup.parse(new String(articleContent));
+        return convert(baseUrl, document).normalise().toString().getBytes();
+    }
+
+    /**
+     * Converts all the urls in a document to its absolute equivalent,
+     * so it can be saved on disk and used again later.
+     */
+    private static Document convert(URL baseUrl, Document document) {
+        // Convert all href and src attributes
+        for (Element e : document.getAllElements()) {
+
+            if (e.hasAttr("href")) {
+                String link = e.attr("href");
+                try {
+                    String absLink = new URL(baseUrl, link).toExternalForm();
+                    e.attr("href", absLink);
+                } catch (MalformedURLException mue) {
+                    // do nothing because if the URL is malformed,
+                    // we simply need not convert the URL.
+                }
+
+            } else if (e.hasAttr("src")) {
+                String link = e.attr("src");
+                try {
+                    String absLink = new URL(baseUrl, link).toExternalForm();
+                    e.attr("src", absLink);
+                } catch (MalformedURLException mue) {
+                    // do nothing because if the URL is malformed,
+                    // we simply need not convert the URL.
+                }
+            }
+
+        }
+
+        return document;
+    }
+
+}

--- a/src/main/java/seedu/address/util/Network.java
+++ b/src/main/java/seedu/address/util/Network.java
@@ -1,4 +1,4 @@
-package seedu.address.network;
+package seedu.address.util;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -26,6 +26,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.mocks.ModelManagerStub;
+import seedu.address.mocks.TemporaryStorageManager;
 import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
@@ -54,10 +55,7 @@ public class LogicManagerTest {
 
     @Before
     public void setUp() throws Exception {
-        JsonEntryBookStorage addressBookStorage = new JsonEntryBookStorage(temporaryFolder.newFile().toPath());
-        JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.newFile().toPath());
-        ArticleStorage articleStorage = new DataDirectoryArticleStorage(temporaryFolder.newFolder().toPath());
-        StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage, articleStorage);
+        StorageManager storage = new TemporaryStorageManager(temporaryFolder);
         model = new ModelManager(new EntryBook(), new UserPrefs(), storage);
         logic = new LogicManager(model);
     }

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalEntries.CRUX_LINK_NO_DESCRIPTION_COMPLETE;
@@ -8,10 +10,20 @@ import static seedu.address.testutil.TypicalEntries.CRUX_LINK_NO_TITLE_COMPLETE;
 import static seedu.address.testutil.TypicalEntries.CRUX_LINK_NO_TITLE_INCOMPLETE;
 import static seedu.address.testutil.TypicalEntries.CRUX_LINK_NO_TITLE_NO_DESCRIPTION_COMPLETE;
 import static seedu.address.testutil.TypicalEntries.CRUX_LINK_NO_TITLE_NO_DESCRIPTION_INCOMPLETE;
+import static seedu.address.testutil.TypicalEntries.ENTRY_WITH_ABSOLUTE_LINK;
+import static seedu.address.testutil.TypicalEntries.ENTRY_WITH_RELATIVE_LINK;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.mocks.TemporaryStorageManager;
 import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.Model;
 import seedu.address.model.entry.Entry;
@@ -21,6 +33,9 @@ import seedu.address.testutil.EntryBuilder;
  * Contains integration tests (interaction with the Model) for {@code AddCommand}.
  */
 public class AddCommandIntegrationTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     private Model model = new TypicalModelManagerStub();
     private CommandHistory commandHistory = new CommandHistory();
@@ -68,6 +83,25 @@ public class AddCommandIntegrationTest {
         Entry entryInList = model.getListEntryBook().getEntryList().get(0);
         assertCommandFailure(new AddCommand(entryInList), model, commandHistory,
                 AddCommand.MESSAGE_DUPLICATE_PERSON);
+    }
+
+    @Test
+    public void execute_linksAreConverted() throws CommandException, IOException {
+
+        // We need to make model have a Storage for this test
+        model = new TypicalModelManagerStub(new TemporaryStorageManager(temporaryFolder));
+
+        new AddCommand(ENTRY_WITH_RELATIVE_LINK).execute(model, commandHistory);
+        Path relativeArticlePath = model.getStorage().getArticlePath(ENTRY_WITH_RELATIVE_LINK.getLink().value);
+        byte[] relativeArticleContent = Files.readAllBytes(relativeArticlePath);
+
+        new AddCommand(ENTRY_WITH_ABSOLUTE_LINK).execute(model, commandHistory);
+        Path absoluteArticlePath = model.getStorage().getArticlePath(ENTRY_WITH_ABSOLUTE_LINK.getLink().value);
+        byte[] absoluteArticleContent = Files.readAllBytes(absoluteArticlePath);
+
+        assertTrue(relativeArticleContent.length > 0);
+        assertTrue(absoluteArticleContent.length > 0);
+        assertArrayEquals(relativeArticleContent, absoluteArticleContent);
     }
 
 }

--- a/src/test/java/seedu/address/mocks/TemporaryStorageManager.java
+++ b/src/test/java/seedu/address/mocks/TemporaryStorageManager.java
@@ -1,0 +1,25 @@
+package seedu.address.mocks;
+
+import java.io.IOException;
+
+import org.junit.rules.TemporaryFolder;
+
+import seedu.address.storage.DataDirectoryArticleStorage;
+import seedu.address.storage.JsonEntryBookStorage;
+import seedu.address.storage.JsonUserPrefsStorage;
+import seedu.address.storage.StorageManager;
+
+/**
+ * A mock for Storage for ease of creating objects in tests
+ */
+public class TemporaryStorageManager extends StorageManager {
+
+    public TemporaryStorageManager(TemporaryFolder temporaryFolder) throws IOException {
+        super(
+                new JsonEntryBookStorage(temporaryFolder.newFile().toPath()),
+                new JsonUserPrefsStorage(temporaryFolder.newFile().toPath()),
+                new DataDirectoryArticleStorage(temporaryFolder.newFolder().toPath())
+        );
+    }
+
+}

--- a/src/test/java/seedu/address/mocks/TypicalModelManagerStub.java
+++ b/src/test/java/seedu/address/mocks/TypicalModelManagerStub.java
@@ -4,6 +4,7 @@ import static seedu.address.testutil.TypicalEntries.getTypicalEntryBook;
 
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.storage.Storage;
 
 /**
  * A mock to create a ModelManager initialised with typical entries.
@@ -12,6 +13,10 @@ public class TypicalModelManagerStub extends ModelManager {
 
     public TypicalModelManagerStub() {
         super(getTypicalEntryBook(), new UserPrefs(), new StorageStub());
+    }
+
+    public TypicalModelManagerStub(Storage storage) {
+        super(getTypicalEntryBook(), new UserPrefs(), storage);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalEntries.java
+++ b/src/test/java/seedu/address/testutil/TypicalEntries.java
@@ -123,6 +123,11 @@ public class TypicalEntries {
             + "personal attorney and fixer held millions rapt with allegations of fraud, coded orders to lie and "
             + "hundreds of threats. Many of those assertions had been explored before, as these articles show.";
 
+    public static final String RELATIVE_LINK_ARTICLE_URL = MainApp.class
+            .getResource("/util/relativeLinkedArticle.html").toExternalForm();
+    public static final String ABSOLUTE_LINK_ARTICLE_URL = MainApp.class
+            .getResource("/util/absoluteLinkedArticle.html").toExternalForm();
+
     public static final Entry STUB_LINK_NO_TITLE_NO_DESCRIPTION_INCOMPLETE = new EntryBuilder()
             .withTitle("")
             .withDescription("")
@@ -226,6 +231,17 @@ public class TypicalEntries {
             .withTitle(DUMMY_TITLE)
             .withDescription(DUMMY_DESCRIPTION)
             .withLink(CRUX_LINK_URL)
+            .build();
+
+    public static final Entry ENTRY_WITH_RELATIVE_LINK = new EntryBuilder()
+            .withTitle(DUMMY_TITLE)
+            .withDescription(DUMMY_DESCRIPTION)
+            .withLink(RELATIVE_LINK_ARTICLE_URL)
+            .build();
+    public static final Entry ENTRY_WITH_ABSOLUTE_LINK = new EntryBuilder()
+            .withTitle(DUMMY_TITLE)
+            .withDescription(DUMMY_DESCRIPTION)
+            .withLink(ABSOLUTE_LINK_ARTICLE_URL)
             .build();
 
     // For testing of networking

--- a/src/test/java/seedu/address/util/AbsoluteUrlDocumentConverterTest.java
+++ b/src/test/java/seedu/address/util/AbsoluteUrlDocumentConverterTest.java
@@ -1,0 +1,118 @@
+package seedu.address.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.jsoup.Jsoup;
+import org.junit.Test;
+
+public class AbsoluteUrlDocumentConverterTest {
+
+    private URL baseUrl = new URL("https://en.wikipedia.org/wiki/Therapsid");
+
+    public AbsoluteUrlDocumentConverterTest() throws MalformedURLException {
+    }
+
+    @Test
+    public void convert_linksProperlyConverted() {
+        assertLinkConversion(
+                "<!doctype html><body><a href=\"%s\"></a></body>");
+        assertLinkConversion(
+                "<!doctype html><body><a junk=\"foo\" href=\"%s\"></a></body>");
+        assertLinkConversion(
+                "<!doctype html><body><a href=\"%s\" junk=\"foo\"></a></body>");
+    }
+
+    @Test
+    public void convert_styleSheetLinkProperlyConverted() {
+        assertLinkConversion(
+                "<!doctype html><head><link rel=\"stylesheet\" href=\"%s\"></head><body></body>");
+        assertLinkConversion(
+                "<!doctype html><head><link rel=\"stylesheet\" junk=\"foo\" href=\"%s\"></head><body></body>");
+        assertLinkConversion(
+                "<!doctype html><head><link rel=\"stylesheet\" href=\"%s\" junk=\"foo\"></head><body></body>");
+    }
+
+    @Test
+    public void convert_imgLinkProperlyConverted() {
+        assertLinkConversion(
+                "<!doctype html><head></head><body><img src=\"%s\"></body>");
+        assertLinkConversion(
+                "<!doctype html><head></head><body><img junk=\"foo\" src=\"%s\"></body>");
+        assertLinkConversion(
+                "<!doctype html><head></head><body><img src=\"%s\" junk=\"foo\"></body>");
+    }
+
+    @Test
+    public void convert_scriptLinkProperlyConverted() {
+        assertLinkConversion(
+                "<!doctype html><head></head><body><script src=\"%s\"></body>");
+        assertLinkConversion(
+                "<!doctype html><head></head><body><script junk=\"foo\" src=\"%s\"></body>");
+        assertLinkConversion(
+                "<!doctype html><head></head><body><script src=\"%s\" junk=\"foo\"></body>");
+    }
+
+    /**
+     * Asserts that using the given format string to substitute in various links,
+     * that the document will undergo the conversion to absolute links correctly.
+     */
+    private void assertLinkConversion(String formatString) {
+
+        // Absolute links are preserved
+        assertSuccessfulConversion(
+                String.format(formatString, "http://absolute.link/and/path"),
+                baseUrl,
+                String.format(formatString, "http://absolute.link/and/path")
+        );
+
+        // Protocol relative links are converted
+        assertSuccessfulConversion(
+                String.format(formatString, "https://absolute.link/and/path"),
+                baseUrl,
+                String.format(formatString, "//absolute.link/and/path")
+        );
+
+        // Domain relative links are converted
+        assertSuccessfulConversion(
+                String.format(formatString, "https://en.wikipedia.org/and/path"),
+                baseUrl,
+                String.format(formatString, "/and/path")
+        );
+
+        // Relative links are converted
+        assertSuccessfulConversion(
+                String.format(formatString, "https://en.wikipedia.org/wiki/and/path"),
+                baseUrl,
+                String.format(formatString, "and/path")
+        );
+
+    }
+
+    /**
+     * Asserts that the conversion of inputDocument was successful and its result matches the expected document.
+     */
+    private void assertSuccessfulConversion(String expected, URL baseUrl, String inputDocument) {
+        assertEquals(
+                new String(normalizeHtml(expected.getBytes())),
+                new String(normalizeHtml(AbsoluteUrlDocumentConverter.convert(baseUrl, inputDocument.getBytes()))));
+    }
+
+    /**
+     * Formats the html to some clean standardised output format
+     */
+    private byte[] normalizeHtml(byte[] html) {
+        // We parse and output until it stops differing.
+        // Sometimes after 1 or 2 passes there can still be whitespace differences.
+        // I didn't want to hardcode 3 passes because I'm no longer sure 3 passes would be enough.
+        String cur = new String(html);
+        String prev = null;
+        while (!cur.equals(prev)) {
+            prev = cur;
+            cur = Jsoup.parse(cur).toString();
+        }
+        return cur.getBytes();
+    }
+}

--- a/src/test/java/seedu/address/util/NetworkTest.java
+++ b/src/test/java/seedu/address/util/NetworkTest.java
@@ -1,15 +1,15 @@
-package seedu.address.network;
+package seedu.address.util;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static seedu.address.network.Network.fetchAsStream;
-import static seedu.address.network.Network.fetchAsString;
 import static seedu.address.testutil.TypicalEntries.FILE_TEST_CONTENTS;
 import static seedu.address.testutil.TypicalEntries.VALID_FILE_LINK;
 import static seedu.address.testutil.TypicalEntries.VALID_HTTPS_LINK;
 import static seedu.address.testutil.TypicalEntries.VALID_HTTP_LINK;
+import static seedu.address.util.Network.fetchAsStream;
+import static seedu.address.util.Network.fetchAsString;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/test/resources/util/absoluteLinkedArticle.html
+++ b/src/test/resources/util/absoluteLinkedArticle.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<body><a href="file:/some/relative/link"></a></body>

--- a/src/test/resources/util/relativeLinkedArticle.html
+++ b/src/test/resources/util/relativeLinkedArticle.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<body><a href="/some/relative/link"></a></body>


### PR DESCRIPTION
Resolves #99.

### Summary of changes
- Minor refactors:
  - `TemporaryStorageManager` that makes a `Storage` which actually works
  - Rename `.network` to `.util`
- Add the document converter that resolves links
- Make `add` command use the document converter prior to saving the article

### Part of epics
- #28 Offline support