### PR TITLE
Remove link field from edit command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LINK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ENTRIES;
@@ -22,7 +21,6 @@ import seedu.address.model.Model;
 import seedu.address.model.entry.Address;
 import seedu.address.model.entry.Description;
 import seedu.address.model.entry.Entry;
-import seedu.address.model.entry.Link;
 import seedu.address.model.entry.Title;
 import seedu.address.model.tag.Tag;
 
@@ -36,19 +34,19 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the entry identified "
             + "by the index number used in the displayed entry list. "
-            + "Existing values will be overwritten by the input values.\n"
+            + "Existing values will be overwritten by the input values. "
+            + "Links cannot be editted.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_TITLE + "TITLE] "
             + "[" + PREFIX_DESCRIPTION + "COMMENT] "
-            + "[" + PREFIX_LINK + "LINK] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_DESCRIPTION + "New description "
-            + PREFIX_LINK + "https://new-link.com";
+            + PREFIX_TITLE + "New title "
+            + PREFIX_DESCRIPTION + "New description ";
 
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Entry: %1$s";
+    public static final String MESSAGE_EDIT_ENTRY_SUCCESS = "Edited Entry: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This entry already exists in the entry book.";
+    public static final String MESSAGE_DUPLICATE_ENTRY = "This entry already exists in the entry book.";
 
     private final Index index;
     private final EditEntryDescriptor editEntryDescriptor;
@@ -75,31 +73,30 @@ public class EditCommand extends Command {
         }
 
         Entry entryToEdit = lastShownList.get(index.getZeroBased());
-        Entry editedEntry = createEditedPerson(entryToEdit, editEntryDescriptor);
+        Entry editedEntry = createEditedEntry(entryToEdit, editEntryDescriptor);
 
         if (!entryToEdit.isSameEntry(editedEntry) && model.hasEntry(editedEntry)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            throw new CommandException(MESSAGE_DUPLICATE_ENTRY);
         }
 
         model.setListEntry(entryToEdit, editedEntry);
         model.updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedEntry));
+        return new CommandResult(String.format(MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry));
     }
 
     /**
      * Creates and returns a {@code Entry} with the details of {@code entryToEdit}
      * edited with {@code editEntryDescriptor}.
      */
-    private static Entry createEditedPerson(Entry entryToEdit, EditEntryDescriptor editEntryDescriptor) {
+    private static Entry createEditedEntry(Entry entryToEdit, EditEntryDescriptor editEntryDescriptor) {
         assert entryToEdit != null;
 
         Title updatedTitle = editEntryDescriptor.getTitle().orElse(entryToEdit.getTitle());
         Description updatedDescription = editEntryDescriptor.getDescription().orElse(entryToEdit.getDescription());
-        Link updatedLink = editEntryDescriptor.getLink().orElse(entryToEdit.getLink());
         Address updatedAddress = editEntryDescriptor.getAddress().orElse(entryToEdit.getAddress());
         Set<Tag> updatedTags = editEntryDescriptor.getTags().orElse(entryToEdit.getTags());
 
-        return new Entry(updatedTitle, updatedDescription, updatedLink, updatedAddress, updatedTags);
+        return new Entry(updatedTitle, updatedDescription, entryToEdit.getLink(), updatedAddress, updatedTags);
     }
 
     @Override
@@ -127,7 +124,6 @@ public class EditCommand extends Command {
     public static class EditEntryDescriptor {
         private Title title;
         private Description description;
-        private Link link;
         private Address address;
         private Set<Tag> tags;
 
@@ -140,7 +136,6 @@ public class EditCommand extends Command {
         public EditEntryDescriptor(EditEntryDescriptor toCopy) {
             setTitle(toCopy.title);
             setDescription(toCopy.description);
-            setLink(toCopy.link);
             setAddress(toCopy.address);
             setTags(toCopy.tags);
         }
@@ -149,7 +144,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(title, description, link, address, tags);
+            return CollectionUtil.isAnyNonNull(title, description, address, tags);
         }
 
         public void setTitle(Title title) {
@@ -166,14 +161,6 @@ public class EditCommand extends Command {
 
         public Optional<Description> getDescription() {
             return Optional.ofNullable(description);
-        }
-
-        public void setLink(Link link) {
-            this.link = link;
-        }
-
-        public Optional<Link> getLink() {
-            return Optional.ofNullable(link);
         }
 
         public void setAddress(Address address) {
@@ -218,7 +205,6 @@ public class EditCommand extends Command {
 
             return getTitle().equals(e.getTitle())
                     && getDescription().equals(e.getDescription())
-                    && getLink().equals(e.getLink())
                     && getAddress().equals(e.getAddress())
                     && getTags().equals(e.getTags());
         }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_LINK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
@@ -33,7 +32,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args,
-                                           PREFIX_TITLE, PREFIX_DESCRIPTION, PREFIX_LINK, PREFIX_ADDRESS, PREFIX_TAG);
+                                           PREFIX_TITLE, PREFIX_DESCRIPTION, PREFIX_ADDRESS, PREFIX_TAG);
 
         Index index;
 
@@ -49,9 +48,6 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
             editEntryDescriptor.setDescription(ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION)));
-        }
-        if (argMultimap.getValue(PREFIX_LINK).isPresent()) {
-            editEntryDescriptor.setLink(ParserUtil.parseLink(argMultimap.getValue(PREFIX_LINK)));
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editEntryDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS)));

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -84,10 +84,10 @@ public class CommandTestUtil {
 
     static {
         DESC_AMY = new EditEntryDescriptorBuilder().withTitle(VALID_TITLE_AMY)
-                .withDescription(VALID_DESCRIPTION_AMY).withLink(VALID_LINK_AMY).withAddress(VALID_ADDRESS_AMY)
+                .withDescription(VALID_DESCRIPTION_AMY).withAddress(VALID_ADDRESS_AMY)
                 .withTags(VALID_TAG_TECH).build();
         DESC_BOB = new EditEntryDescriptorBuilder().withTitle(VALID_TITLE_BOB)
-                .withDescription(VALID_DESCRIPTION_BOB).withLink(VALID_LINK_BOB).withAddress(VALID_ADDRESS_BOB)
+                .withDescription(VALID_DESCRIPTION_BOB).withAddress(VALID_ADDRESS_BOB)
                 .withTags(VALID_TAG_SCIENCE, VALID_TAG_TECH).build();
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -35,7 +35,8 @@ public class EditCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
-        Entry editedEntry = new EntryBuilder().build();
+        Entry entryToEdit = model.getFilteredEntryList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        Entry editedEntry = new EntryBuilder().withLink(entryToEdit.getLink().value).build();
         EditCommand.EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder(editedEntry).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_ENTRY, descriptor);
 
@@ -95,27 +96,6 @@ public class EditCommandTest {
         expectedModel.setListEntry(model.getFilteredEntryList().get(0), editedEntry);
 
         assertCommandSuccess(editCommand, model, commandHistory, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_duplicatePersonUnfilteredList_failure() {
-        Entry firstEntry = model.getFilteredEntryList().get(INDEX_FIRST_ENTRY.getZeroBased());
-        EditCommand.EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder(firstEntry).build();
-        EditCommand editCommand = new EditCommand(INDEX_SECOND_ENTRY, descriptor);
-
-        assertCommandFailure(editCommand, model, commandHistory, EditCommand.MESSAGE_DUPLICATE_ENTRY);
-    }
-
-    @Test
-    public void execute_duplicatePersonFilteredList_failure() {
-        showPersonAtIndex(model, INDEX_FIRST_ENTRY);
-
-        // edit entry in filtered list into a duplicate in address book
-        Entry entryInList = model.getListEntryBook().getEntryList().get(INDEX_SECOND_ENTRY.getZeroBased());
-        EditCommand editCommand = new EditCommand(INDEX_FIRST_ENTRY,
-                new EditEntryDescriptorBuilder(entryInList).build());
-
-        assertCommandFailure(editCommand, model, commandHistory, EditCommand.MESSAGE_DUPLICATE_ENTRY);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -39,7 +39,7 @@ public class EditCommandTest {
         EditCommand.EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder(editedEntry).build();
         EditCommand editCommand = new EditCommand(INDEX_FIRST_ENTRY, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedEntry);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry);
 
         Model expectedModel = model.clone();
         expectedModel.setListEntry(model.getFilteredEntryList().get(0), editedEntry);
@@ -60,7 +60,7 @@ public class EditCommandTest {
                 .withDescription(VALID_DESCRIPTION_BOB).withTags(VALID_TAG_SCIENCE).build();
         EditCommand editCommand = new EditCommand(indexLastPerson, descriptor);
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedEntry);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry);
 
         Model expectedModel = model.clone();
         expectedModel.setListEntry(lastEntry, editedEntry);
@@ -73,7 +73,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_ENTRY, new EditCommand.EditEntryDescriptor());
         Entry editedEntry = model.getFilteredEntryList().get(INDEX_FIRST_ENTRY.getZeroBased());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedEntry);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry);
 
         Model expectedModel = model.clone();
 
@@ -89,7 +89,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_ENTRY,
                 new EditEntryDescriptorBuilder().withTitle(VALID_TITLE_BOB).build());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedEntry);
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry);
 
         Model expectedModel = model.clone();
         expectedModel.setListEntry(model.getFilteredEntryList().get(0), editedEntry);
@@ -103,7 +103,7 @@ public class EditCommandTest {
         EditCommand.EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder(firstEntry).build();
         EditCommand editCommand = new EditCommand(INDEX_SECOND_ENTRY, descriptor);
 
-        assertCommandFailure(editCommand, model, commandHistory, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, commandHistory, EditCommand.MESSAGE_DUPLICATE_ENTRY);
     }
 
     @Test
@@ -115,7 +115,7 @@ public class EditCommandTest {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_ENTRY,
                 new EditEntryDescriptorBuilder(entryInList).build());
 
-        assertCommandFailure(editCommand, model, commandHistory, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(editCommand, model, commandHistory, EditCommand.MESSAGE_DUPLICATE_ENTRY);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditEntryDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditEntryDescriptorTest.java
@@ -6,7 +6,6 @@ import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_LINK_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SCIENCE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_BOB;
 
@@ -41,10 +40,6 @@ public class EditEntryDescriptorTest {
 
         // different phone -> returns false
         editedAmy = new EditEntryDescriptorBuilder(DESC_AMY).withDescription(VALID_DESCRIPTION_BOB).build();
-        assertFalse(DESC_AMY.equals(editedAmy));
-
-        // different email -> returns false
-        editedAmy = new EditEntryDescriptorBuilder(DESC_AMY).withLink(VALID_LINK_BOB).build();
         assertFalse(DESC_AMY.equals(editedAmy));
 
         // different address -> returns false

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -9,26 +9,22 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DESCRIPTION;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DESCRIPTION_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_LINK;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_LINK_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TITLE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TITLE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.LINK_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.LINK_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_SCIENCE;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_TECH;
 import static seedu.address.logic.commands.CommandTestUtil.TITLE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.TITLE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_LINK_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_LINK_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SCIENCE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_TECH;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_BOB;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -43,7 +39,6 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditEntryDescriptor;
 import seedu.address.model.entry.Address;
 import seedu.address.model.entry.Description;
-import seedu.address.model.entry.Link;
 import seedu.address.model.entry.Title;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditEntryDescriptorBuilder;
@@ -91,15 +86,13 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1"
             + INVALID_DESCRIPTION_DESC, Description.formExceptionMessage(INVALID_DESCRIPTION.trim())); // invalid desc
         assertParseFailure(parser, "1"
-            + INVALID_LINK_DESC, Link.formExceptionMessage(INVALID_LINK.trim())); // invalid link
-        assertParseFailure(parser, "1"
             + INVALID_ADDRESS_DESC, Address.formExceptionMessage(INVALID_ADDRESS.trim())); // invalid address
         assertParseFailure(parser, "1"
             + INVALID_TAG_DESC, Tag.formExceptionMessage(INVALID_TAG.trim())); // invalid tag
 
-        // invalid description followed by valid link
+        // invalid description followed by valid title
         assertParseFailure(parser, "1"
-            + INVALID_DESCRIPTION_DESC + LINK_DESC_AMY, Description.formExceptionMessage(INVALID_DESCRIPTION.trim()));
+            + INVALID_DESCRIPTION_DESC + TITLE_DESC_AMY, Description.formExceptionMessage(INVALID_DESCRIPTION.trim()));
 
         // valid description followed by invalid description.
         // The test case for invalid description followed by valid description
@@ -119,7 +112,7 @@ public class EditCommandParserTest {
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser,
-            "1" + INVALID_TITLE_DESC + INVALID_LINK_DESC + VALID_ADDRESS_AMY + VALID_DESCRIPTION_AMY,
+            "1" + INVALID_TITLE_DESC + INVALID_DESCRIPTION_DESC + VALID_ADDRESS_AMY + VALID_DESCRIPTION_AMY,
                 Title.formExceptionMessage(INVALID_TITLE.trim()));
     }
 
@@ -127,10 +120,10 @@ public class EditCommandParserTest {
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_ENTRY;
         String userInput = targetIndex.getOneBased() + DESCRIPTION_DESC_BOB + TAG_DESC_SCIENCE
-                + LINK_DESC_AMY + ADDRESS_DESC_AMY + TITLE_DESC_AMY + TAG_DESC_TECH;
+                + ADDRESS_DESC_AMY + TITLE_DESC_AMY + TAG_DESC_TECH;
 
         EditCommand.EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder().withTitle(VALID_TITLE_AMY)
-                .withDescription(VALID_DESCRIPTION_BOB).withLink(VALID_LINK_AMY).withAddress(VALID_ADDRESS_AMY)
+                .withDescription(VALID_DESCRIPTION_BOB).withAddress(VALID_ADDRESS_AMY)
                 .withTags(VALID_TAG_SCIENCE, VALID_TAG_TECH).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
@@ -140,10 +133,10 @@ public class EditCommandParserTest {
     @Test
     public void parse_someFieldsSpecified_success() {
         Index targetIndex = INDEX_FIRST_ENTRY;
-        String userInput = targetIndex.getOneBased() + DESCRIPTION_DESC_BOB + LINK_DESC_AMY;
+        String userInput = targetIndex.getOneBased() + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB;
 
-        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder().withDescription(VALID_DESCRIPTION_BOB)
-                .withLink(VALID_LINK_AMY).build();
+        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder()
+            .withTitle(VALID_TITLE_BOB).withDescription(VALID_DESCRIPTION_BOB).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -151,22 +144,16 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_oneFieldSpecified_success() {
-        // name
+        // title
         Index targetIndex = INDEX_THIRD_ENTRY;
         String userInput = targetIndex.getOneBased() + TITLE_DESC_AMY;
         EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder().withTitle(VALID_TITLE_AMY).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // phone
+        // description
         userInput = targetIndex.getOneBased() + DESCRIPTION_DESC_AMY;
         descriptor = new EditEntryDescriptorBuilder().withDescription(VALID_DESCRIPTION_AMY).build();
-        expectedCommand = new EditCommand(targetIndex, descriptor);
-        assertParseSuccess(parser, userInput, expectedCommand);
-
-        // email
-        userInput = targetIndex.getOneBased() + LINK_DESC_AMY;
-        descriptor = new EditEntryDescriptorBuilder().withLink(VALID_LINK_AMY).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
@@ -186,13 +173,12 @@ public class EditCommandParserTest {
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
         Index targetIndex = INDEX_FIRST_ENTRY;
-        String userInput = targetIndex.getOneBased() + DESCRIPTION_DESC_AMY + ADDRESS_DESC_AMY + LINK_DESC_AMY
-                + TAG_DESC_TECH + DESCRIPTION_DESC_AMY + ADDRESS_DESC_AMY + LINK_DESC_AMY + TAG_DESC_TECH
-                + DESCRIPTION_DESC_BOB + ADDRESS_DESC_BOB + LINK_DESC_BOB + TAG_DESC_SCIENCE;
+        String userInput = targetIndex.getOneBased() + DESCRIPTION_DESC_AMY + ADDRESS_DESC_AMY
+                + TAG_DESC_TECH + DESCRIPTION_DESC_AMY + ADDRESS_DESC_AMY + TAG_DESC_TECH
+                + DESCRIPTION_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_SCIENCE;
 
         EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder().withDescription(VALID_DESCRIPTION_BOB)
-                .withLink(VALID_LINK_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_TECH, VALID_TAG_SCIENCE)
-                .build();
+                .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_TECH, VALID_TAG_SCIENCE).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -210,9 +196,9 @@ public class EditCommandParserTest {
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // other valid values specified
-        userInput = targetIndex.getOneBased() + LINK_DESC_BOB + INVALID_DESCRIPTION_DESC + ADDRESS_DESC_BOB
+        userInput = targetIndex.getOneBased() + TITLE_DESC_BOB + INVALID_DESCRIPTION_DESC + ADDRESS_DESC_BOB
                 + DESCRIPTION_DESC_BOB;
-        descriptor = new EditEntryDescriptorBuilder().withDescription(VALID_DESCRIPTION_BOB).withLink(VALID_LINK_BOB)
+        descriptor = new EditEntryDescriptorBuilder().withDescription(VALID_DESCRIPTION_BOB).withTitle(VALID_TITLE_BOB)
                 .withAddress(VALID_ADDRESS_BOB).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);

--- a/src/test/java/seedu/address/testutil/EditEntryDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditEntryDescriptorBuilder.java
@@ -9,7 +9,6 @@ import seedu.address.logic.commands.EditCommand.EditEntryDescriptor;
 import seedu.address.model.entry.Address;
 import seedu.address.model.entry.Description;
 import seedu.address.model.entry.Entry;
-import seedu.address.model.entry.Link;
 import seedu.address.model.entry.Title;
 import seedu.address.model.tag.Tag;
 
@@ -35,7 +34,6 @@ public class EditEntryDescriptorBuilder {
         descriptor = new EditCommand.EditEntryDescriptor();
         descriptor.setTitle(entry.getTitle());
         descriptor.setDescription(entry.getDescription());
-        descriptor.setLink(entry.getLink());
         descriptor.setAddress(entry.getAddress());
         descriptor.setTags(entry.getTags());
     }
@@ -53,14 +51,6 @@ public class EditEntryDescriptorBuilder {
      */
     public EditEntryDescriptorBuilder withDescription(String description) {
         descriptor.setDescription(new Description(description));
-        return this;
-    }
-
-    /**
-     * Sets the {@code Link} of the {@code EditEntryDescriptor} that we are building.
-     */
-    public EditEntryDescriptorBuilder withLink(String link) {
-        descriptor.setLink(new Link(link));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/EntryUtil.java
+++ b/src/test/java/seedu/address/testutil/EntryUtil.java
@@ -54,7 +54,6 @@ public class EntryUtil {
         StringBuilder sb = new StringBuilder();
         descriptor.getTitle().ifPresent(name -> sb.append(PREFIX_TITLE).append(name.fullTitle).append(" "));
         descriptor.getDescription().ifPresent(phone -> sb.append(PREFIX_DESCRIPTION).append(phone.value).append(" "));
-        descriptor.getLink().ifPresent(email -> sb.append(PREFIX_LINK).append(email.value).append(" "));
         descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -177,32 +177,32 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased()
                 + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
                 + ADDRESS_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_ENTRY);
 
         /* Case: edit a entry with new values same as another entry's values but with different tags -> rejected */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased()
                 + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
                 + ADDRESS_DESC_BOB + TAG_DESC_SCIENCE;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_ENTRY);
 
         /* Case: edit a entry with new values same as another entry's values but with different title -> rejected */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased()
             + TITLE_DESC_AMY + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
             + ADDRESS_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_ENTRY);
 
         /* Case: edit entry with new values same as another entry's values but with different description -> rejected */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased()
             + TITLE_DESC_BOB + DESCRIPTION_DESC_AMY + LINK_DESC_BOB
             + ADDRESS_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_ENTRY);
 
         // To be deprecated
         /* Case: edit a entry with new values same as another entry's values but with different link -> rejected
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased()
                 + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_AMY
                 + ADDRESS_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_PERSON);
+        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_ENTRY);
         */
     }
 
@@ -231,7 +231,7 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         expectedModel.updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
 
         assertCommandSuccess(command, expectedModel,
-                String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedEntry), expectedSelectedCardIndex);
+                String.format(EditCommand.MESSAGE_EDIT_ENTRY_SUCCESS, editedEntry), expectedSelectedCardIndex);
     }
 
     /**

--- a/src/test/java/systemtests/EditCommandSystemTest.java
+++ b/src/test/java/systemtests/EditCommandSystemTest.java
@@ -1,27 +1,20 @@
 package systemtests;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DESCRIPTION;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DESCRIPTION_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_LINK;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_LINK_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TITLE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_TITLE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.LINK_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.LINK_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_SCIENCE;
 import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_TECH;
-import static seedu.address.logic.commands.CommandTestUtil.TITLE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.TITLE_DESC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_LINK_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SCIENCE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_TECH;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_BOB;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ENTRIES;
@@ -38,49 +31,62 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.model.Model;
 import seedu.address.model.entry.Description;
 import seedu.address.model.entry.Entry;
-import seedu.address.model.entry.Link;
 import seedu.address.model.entry.Title;
 import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EntryBuilder;
-import seedu.address.testutil.EntryUtil;
 
 public class EditCommandSystemTest extends AddressBookSystemTest {
 
     @Test
     public void edit() {
-        Model model = getModel();
-
         /* ----------------- Performing edit operation while an unfiltered list is being shown ---------------------- */
 
         /* Case: edit all fields, command with leading spaces, trailing spaces and multiple spaces between each field
          * -> edited
          */
         Index index = INDEX_FIRST_ENTRY;
+        Entry entryToEdit = getModel().getFilteredEntryList().get(index.getZeroBased());
+
         String command = " " + EditCommand.COMMAND_WORD + "  " + index.getOneBased() + "  " + TITLE_DESC_BOB + "  "
-                + DESCRIPTION_DESC_BOB + " " + LINK_DESC_BOB + "  " + ADDRESS_DESC_BOB + " " + TAG_DESC_SCIENCE + " ";
-        Entry editedEntry = new EntryBuilder(BOB).withTags(VALID_TAG_SCIENCE).build();
+                + DESCRIPTION_DESC_BOB + " " + TAG_DESC_SCIENCE + " " + TAG_DESC_TECH + " ";
+        Entry editedEntry = new EntryBuilder(BOB)
+            .withLink(entryToEdit.getLink().value)
+            .withAddress(entryToEdit.getAddress().value)
+            .withTags(VALID_TAG_SCIENCE, VALID_TAG_TECH)
+            .build();
         assertCommandSuccess(command, index, editedEntry);
 
         /* Case: edit a entry with new values same as existing values -> edited */
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased()
-                + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
-        assertCommandSuccess(command, index, BOB);
+                + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
+        assertCommandSuccess(command, index, editedEntry);
 
-        /* Case: edit a entry with new values same as another entry's values but with different link -> edited */
-        assertTrue(getModel().getListEntryBook().getEntryList().contains(BOB));
+        /* Case: edit a entry with new values same as another entry's values -> edited */
+        Entry firstEntry = editedEntry;
+        assertTrue(getModel().getListEntryBook().getEntryList().contains(firstEntry));
+        assertEquals(firstEntry, new EntryBuilder(BOB)
+                                        .withLink(entryToEdit.getLink().value)
+                                        .withAddress(entryToEdit.getAddress().value)
+                                        .build());
+
         index = INDEX_SECOND_ENTRY;
-        assertNotEquals(getModel().getFilteredEntryList().get(index.getZeroBased()), BOB);
+        entryToEdit = getModel().getFilteredEntryList().get(index.getZeroBased());
+        assertNotEquals(entryToEdit, new EntryBuilder(firstEntry)
+            .withLink(entryToEdit.getLink().value)
+            .withAddress(entryToEdit.getAddress().value));
+
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased()
-                + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_AMY
-                + ADDRESS_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
-        editedEntry = new EntryBuilder(BOB).withLink(VALID_LINK_AMY).build();
+                + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
+        editedEntry = new EntryBuilder(firstEntry)
+            .withLink(entryToEdit.getLink().value)
+            .withAddress(entryToEdit.getAddress().value)
+            .build();
         assertCommandSuccess(command, index, editedEntry);
 
         /* Case: clear tags -> cleared */
         index = INDEX_FIRST_ENTRY;
+        entryToEdit = getModel().getFilteredEntryList().get(index.getZeroBased());
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased() + " " + PREFIX_TAG.getPrefix();
-        Entry entryToEdit = getModel().getFilteredEntryList().get(index.getZeroBased());
         editedEntry = new EntryBuilder(entryToEdit).withTags().build();
         assertCommandSuccess(command, index, editedEntry);
 
@@ -112,12 +118,16 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
         Index indexSelected = INDEX_SECOND_ENTRY;
         selectPerson(indexSelected);
         index = INDEX_FIRST_ENTRY;
+        entryToEdit = getModel().getFilteredEntryList().get(index.getZeroBased());
         command = EditCommand.COMMAND_WORD + " " + index.getOneBased()
-                + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
+                + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
+        editedEntry = new EntryBuilder(BOB)
+            .withLink(entryToEdit.getLink().value)
+            .withAddress(entryToEdit.getAddress().value)
+            .build();
         // this can be misleading: card selection actually remains unchanged but the
         // browser's url is updated to reflect the new entry's name
-        assertCommandSuccess(command, index, BOB, indexSelected);
+        assertCommandSuccess(command, index, editedEntry, indexSelected);
 
         /* --------------------------------- Performing invalid edit operation -------------------------------------- */
 
@@ -152,58 +162,10 @@ public class EditCommandSystemTest extends AddressBookSystemTest {
                 + INDEX_FIRST_ENTRY.getOneBased() + INVALID_DESCRIPTION_DESC,
                 Description.formExceptionMessage(INVALID_DESCRIPTION.trim()));
 
-        /* Case: invalid link -> rejected */
-        assertCommandFailure(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_ENTRY.getOneBased() + INVALID_LINK_DESC,
-                Link.formExceptionMessage(INVALID_LINK.trim()));
-
-        // To be deprecated
-        /* Case: invalid address -> rejected
-        assertCommandFailure(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_ENTRY.getOneBased() + INVALID_ADDRESS_DESC,
-                Address.MESSAGE_CONSTRAINTS);
-        */
-
         /* Case: invalid tag -> rejected */
         assertCommandFailure(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_ENTRY.getOneBased() + INVALID_TAG_DESC,
                 Tag.formExceptionMessage(INVALID_TAG.trim()));
-
-        /* Case: edit a entry with new values same as another entry's values -> rejected */
-        executeCommand(EntryUtil.getAddCommand(BOB));
-        assertTrue(getModel().getListEntryBook().getEntryList().contains(BOB));
-        index = INDEX_SECOND_ENTRY;
-        assertFalse(getModel().getFilteredEntryList().get(index.getZeroBased()).equals(BOB));
-        command = EditCommand.COMMAND_WORD + " " + index.getOneBased()
-                + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_ENTRY);
-
-        /* Case: edit a entry with new values same as another entry's values but with different tags -> rejected */
-        command = EditCommand.COMMAND_WORD + " " + index.getOneBased()
-                + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_SCIENCE;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_ENTRY);
-
-        /* Case: edit a entry with new values same as another entry's values but with different title -> rejected */
-        command = EditCommand.COMMAND_WORD + " " + index.getOneBased()
-            + TITLE_DESC_AMY + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
-            + ADDRESS_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_ENTRY);
-
-        /* Case: edit entry with new values same as another entry's values but with different description -> rejected */
-        command = EditCommand.COMMAND_WORD + " " + index.getOneBased()
-            + TITLE_DESC_BOB + DESCRIPTION_DESC_AMY + LINK_DESC_BOB
-            + ADDRESS_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_ENTRY);
-
-        // To be deprecated
-        /* Case: edit a entry with new values same as another entry's values but with different link -> rejected
-        command = EditCommand.COMMAND_WORD + " " + index.getOneBased()
-                + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_AMY
-                + ADDRESS_DESC_BOB + TAG_DESC_TECH + TAG_DESC_SCIENCE;
-        assertCommandFailure(command, EditCommand.MESSAGE_DUPLICATE_ENTRY);
-        */
     }
 
     /**


### PR DESCRIPTION
#### Summary of changes
* Edit command no ignores link field input 
** Example: "edit l/https://example.com ti/Example" is the same as "edit ti/Example"
* Effectively disallows users to edit the link field

Resolves #62 