### PR TITLE
Improve error message when user enters wrong command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -5,7 +5,9 @@ package seedu.address.commons.core;
  */
 public class Messages {
 
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
+    public static final String MESSAGE_UNKNOWN_COMMAND =
+        "Command not found in current context: %s.\n"
+        + "Please check that you have entered your command correctly or if you are in the right context.";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX = "The entry index provided is invalid";
     public static final String MESSAGE_ENTRIES_LISTED_OVERVIEW = "%1$d entries listed!";

--- a/src/main/java/seedu/address/logic/parser/EntryBookArchivesParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookArchivesParser.java
@@ -9,6 +9,7 @@ import seedu.address.logic.commands.DeleteArchiveEntryCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.UnarchiveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ModelContext;
 
 /**
  * Represents the parser for the archive-context.
@@ -43,7 +44,7 @@ public class EntryBookArchivesParser extends EntryBookParser {
             return new UnarchiveCommandParser().parse(arguments);
 
         default:
-            return super.parseCommand(userInput);
+            return super.parseCommand(userInput, ModelContext.CONTEXT_ARCHIVES);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/EntryBookFeedsParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookFeedsParser.java
@@ -11,6 +11,7 @@ import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.SubscribeCommand;
 import seedu.address.logic.commands.UnsubscribeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ModelContext;
 
 /**
  * Represents the parser for the feeds context.
@@ -46,7 +47,7 @@ public class EntryBookFeedsParser extends EntryBookParser {
             return new UnsubscribeCommandParser().parse(arguments);
 
         default:
-            return super.parseCommand(userInput);
+            return super.parseCommand(userInput, ModelContext.CONTEXT_FEEDS);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.RefreshEntryCommand;
 import seedu.address.logic.commands.ViewModeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ModelContext;
 
 /**
  * Represents the parser for the list-context.
@@ -72,7 +73,7 @@ public class EntryBookListParser extends EntryBookParser {
             return new ViewModeCommandParser().parse(arguments);
 
         default:
-            return super.parseCommand(userInput);
+            return super.parseCommand(userInput, ModelContext.CONTEXT_LIST);
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/EntryBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookParser.java
@@ -18,12 +18,13 @@ import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ModelContext;
 
 /**
  * Represents the base parser for any context.
  * It successfully parses a command if and only if the command is context-switching, exit, help or history.
  */
-public class EntryBookParser {
+public abstract class EntryBookParser {
 
     /**
      * Used for initial separation of command word and args.
@@ -38,7 +39,17 @@ public class EntryBookParser {
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
      */
-    public Command parseCommand(String userInput) throws ParseException {
+    public abstract Command parseCommand(String userInput) throws ParseException;
+
+    /**
+     * Parses user input into command for execution.
+     * Parses successfully if and only if the command is context-switching, exit, help or history.
+
+     * @param userInput full user input string
+     * @return the command based on the user input
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    protected Command parseCommand(String userInput, ModelContext currentContext) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
@@ -85,7 +96,7 @@ public class EntryBookParser {
             return new HelpCommand();
 
         default:
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            throw new ParseException(String.format(MESSAGE_UNKNOWN_COMMAND, currentContext));
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/EntryBookSearchParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookSearchParser.java
@@ -10,6 +10,7 @@ import seedu.address.logic.commands.IndexedAddCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.ViewModeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ModelContext;
 
 /**
  * Represents the parser for the search context.
@@ -42,7 +43,7 @@ public class EntryBookSearchParser extends EntryBookParser {
             return new ViewModeCommandParser().parse(arguments);
 
         default:
-            return super.parseCommand(userInput);
+            return super.parseCommand(userInput, ModelContext.CONTEXT_SEARCH);
         }
     }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -30,6 +30,7 @@ import seedu.address.mocks.ModelManagerStub;
 import seedu.address.mocks.TemporaryStorageManager;
 import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
 import seedu.address.model.ModelManager;
 import seedu.address.model.ReadOnlyEntryBook;
 import seedu.address.model.UserPrefs;
@@ -64,7 +65,7 @@ public class LogicManagerTest {
     @Test
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";
-        assertParseException(invalidCommand, MESSAGE_UNKNOWN_COMMAND);
+        assertParseException(invalidCommand, String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_LIST));
         assertHistoryCorrect(invalidCommand);
     }
 

--- a/src/test/java/seedu/address/logic/parser/EntryBookArchivesParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookArchivesParserTest.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.UnarchiveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ModelContext;
 
 public class EntryBookArchivesParserTest {
     @Rule
@@ -48,7 +49,7 @@ public class EntryBookArchivesParserTest {
             parser.parseCommand("histories");
             throw new AssertionError("The expected ParseException was not thrown.");
         } catch (ParseException pe) {
-            assertEquals(MESSAGE_UNKNOWN_COMMAND, pe.getMessage());
+            assertEquals(String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_ARCHIVES), pe.getMessage());
         }
     }
 
@@ -77,7 +78,7 @@ public class EntryBookArchivesParserTest {
     @Test
     public void parseCommand_unknownCommand_throwsParseException() throws Exception {
         thrown.expect(ParseException.class);
-        thrown.expectMessage(MESSAGE_UNKNOWN_COMMAND);
+        thrown.expectMessage(String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_ARCHIVES));
         parser.parseCommand("unknownCommand");
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
@@ -31,6 +31,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.ViewModeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ModelContext;
 import seedu.address.model.entry.Entry;
 import seedu.address.model.entry.EntryContainsSearchTermsPredicate;
 import seedu.address.testutil.EditEntryDescriptorBuilder;
@@ -148,7 +149,7 @@ public class EntryBookListParserTest {
             parser.parseCommand("histories");
             throw new AssertionError("The expected ParseException was not thrown.");
         } catch (ParseException pe) {
-            assertEquals(MESSAGE_UNKNOWN_COMMAND, pe.getMessage());
+            assertEquals(String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_LIST), pe.getMessage());
         }
     }
 
@@ -190,7 +191,7 @@ public class EntryBookListParserTest {
     @Test
     public void parseCommand_unknownCommand_throwsParseException() throws Exception {
         thrown.expect(ParseException.class);
-        thrown.expectMessage(MESSAGE_UNKNOWN_COMMAND);
+        thrown.expectMessage(String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_LIST));
         parser.parseCommand("unknownCommand");
     }
 }

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -39,6 +39,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
 import seedu.address.model.entry.Description;
 import seedu.address.model.entry.Entry;
 import seedu.address.model.entry.Link;
@@ -130,7 +131,7 @@ public class AddCommandSystemTest extends EntryBookSystemTest {
 
         /* Case: invalid keyword -> rejected */
         command = "adds " + EntryUtil.getEntryDetails(toAdd);
-        assertCommandFailure(command, Messages.MESSAGE_UNKNOWN_COMMAND);
+        assertCommandFailure(command, String.format(Messages.MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_LIST));
 
         /* Case: invalid title -> rejected */
         command = AddCommand.COMMAND_WORD + INVALID_TITLE_DESC

--- a/src/test/java/systemtests/ClearCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearCommandSystemTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.mocks.ModelManagerStub;
 import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
 
 public class ClearCommandSystemTest extends EntryBookSystemTest {
 
@@ -25,7 +26,7 @@ public class ClearCommandSystemTest extends EntryBookSystemTest {
         assertSelectedCardUnchanged();
 
         /* Case: mixed case command word -> rejected */
-        assertCommandFailure("ClEaR", MESSAGE_UNKNOWN_COMMAND);
+        assertCommandFailure("ClEaR", String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_LIST));
     }
 
     /**

--- a/src/test/java/systemtests/ContextSwitchSystemTest.java
+++ b/src/test/java/systemtests/ContextSwitchSystemTest.java
@@ -33,7 +33,7 @@ public class ContextSwitchSystemTest extends EntryBookSystemTest {
 
         /* Case: non-list-context command unarchive fails */
         command = UnarchiveCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased();
-        expectedResultMessage = String.format(MESSAGE_UNKNOWN_COMMAND);
+        expectedResultMessage = String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_LIST);
         assertCommandFailure(command, expectedResultMessage);
 
         /* Case: view archives, model should not change */
@@ -49,7 +49,7 @@ public class ContextSwitchSystemTest extends EntryBookSystemTest {
 
         /* Case: non-archives-context command archive fails */
         command = ArchiveCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased();
-        expectedResultMessage = String.format(MESSAGE_UNKNOWN_COMMAND);
+        expectedResultMessage = String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_ARCHIVES);
         assertCommandFailure(command, expectedResultMessage);
 
         /* Case: view entry book, model should not change */

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -16,6 +16,7 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
 import seedu.address.model.entry.Entry;
 
 public class DeleteCommandSystemTest extends EntryBookSystemTest {
@@ -95,7 +96,7 @@ public class DeleteCommandSystemTest extends EntryBookSystemTest {
         assertCommandFailure(DeleteCommand.COMMAND_WORD + " 1 abc", MESSAGE_INVALID_DELETE_COMMAND_FORMAT);
 
         /* Case: mixed case command word -> rejected */
-        assertCommandFailure("DelETE 1", MESSAGE_UNKNOWN_COMMAND);
+        assertCommandFailure("DelETE 1", String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_LIST));
     }
 
     /**

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -20,6 +20,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
 import seedu.address.testutil.FindEntryDescriptorBuilder;
 
 public class FindCommandSystemTest extends EntryBookSystemTest {
@@ -253,7 +254,7 @@ public class FindCommandSystemTest extends EntryBookSystemTest {
         /* Case: mixed case command word -> rejected */
         command = "FiNd" + " "
             + getFindEntryDescriptorDetails(builder.reset().withTitle(KEYWORD_MATCHING_MEIER).build());
-        assertCommandFailure(command, MESSAGE_UNKNOWN_COMMAND);
+        assertCommandFailure(command, String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_LIST));
     }
 
     /**

--- a/src/test/java/systemtests/SelectCommandSystemTest.java
+++ b/src/test/java/systemtests/SelectCommandSystemTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
 
 public class SelectCommandSystemTest extends EntryBookSystemTest {
     @Test
@@ -78,7 +79,7 @@ public class SelectCommandSystemTest extends EntryBookSystemTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE));
 
         /* Case: mixed case command word -> rejected */
-        assertCommandFailure("SeLeCt 1", MESSAGE_UNKNOWN_COMMAND);
+        assertCommandFailure("SeLeCt 1", String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_LIST));
 
         /* Case: select from empty address book -> rejected */
         deleteAllEntries();


### PR DESCRIPTION
Resolves #149, #147, #145, #144, #141, #140, #139.
Resolves #161 for now.

### Summary of changes:
- Change error message of unknown command to:
```
Command not found in current context: %s.
Please check that you have entered your command correctly or if you are in the right context
```