### PR TITLE
Promote subscribe and add to all contexts

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -675,6 +675,24 @@ Examples:
 `delete 2` +
 Deletes the 2nd entry in the archives.
 
+==== Selecting an entry: `select`
+
+Selects the entry identified by the index number used in the displayed entry list for reading.
+
+Format: `select INDEX`
+
+****
+- Selects the entry at the specified `INDEX` for reading.
+- The index refers to the index number shown in the displayed entry list.
+- The index *must be a positive integer* 1`, 2, 3, ...`
+****
+
+Examples:
+
+* `archives` +
+`select 2` +
+Selects the 2nd archived entry.
+
 ==== Clearing all entries : `clear` `[coming in v2.0]`
 Clears all archived entries from the manager.
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -275,6 +275,47 @@ Examples:
 - `import /home/tt/Desktop/export.jtjr` Saves an export file to desktop
 - `import C:\Users\Name\Desktop\export.jtjr` Saves an export file to desktop
 
+[[Add-Command]]
+==== Adding a single entry: `add` `[updated v1.2]`
+
+Adds a single entry from a link URL to your reading list.
+Content is automatically downloaded onto your personal computer.
+
+Format: `add l/URL [ti/TITLE_OVERRIDE] [d/DESCRIPTION_OVERRIDE] [t/TAG]...`
+
+[TIP]
+The `Title` and `Description` fields are automatically filled if you do not provide them.
+[TIP]
+A entry can have any number of tags (including 0).
+
+Examples:
+
+- `add l/https://www.theatlantic.com/magazine/archive/2019/03/ford-ceo-jim-hackett-ux-design-thinking/580438/ d/Explains why UX is important t/Business` +
+Adds a single entry with a description and tagged with “Business”
+
+[[Subscribe-command]]
+==== Subscribing to a feed: `subscribe` `[since v1.3]`
+
+Adds a feed to the manager and subscribes to updates.
+All entries in the subscribed feed will be added to the reading list.
+
+Format: `subscribe l/URL [ti/TITLE_OVERRIDE] [d/DESCRIPTION_OVERRIDE] [t/TAG]..`
+
+[TIP]
+The `Title` and `Description` fields are automatically filled up if you do not provide them.
+[TIP]
+A feed can have any number of tags (including 0)
+
+Examples:
+
+- `subscribe l/https://www.engadget.com/rss.xml ti/Engadget t/Tech` Adds a feed whose name is “Engadget”.
+-  The imported entries will be tagged with “Tech” `[coming in v2.0]`
+
+[WARNING]
+====
+The application may be unresponsive for a short while when adding entries from a large feed.
+====
+
 ==== Listing entered commands : `history`
 
 Lists all the commands that you have entered in reverse chronological order. +
@@ -411,22 +452,7 @@ Format: `stats`
 [[List-Context]]
 === `Reading List` Context Commands
 
-==== Adding a single entry: `add` `[updated v1.2]`
-
-Adds a single entry from a link URL to your reading list.
-Content is automatically downloaded onto your personal computer.
-
-Format: `add l/URL [ti/TITLE_OVERRIDE] [d/DESCRIPTION_OVERRIDE] [t/TAG]...`
-
-[TIP]
-The `Title` and `Description` fields are automatically filled if you do not provide them.
-[TIP]
-A entry can have any number of tags (including 0).
-
-Examples:
-
-- `add l/https://www.theatlantic.com/magazine/archive/2019/03/ford-ceo-jim-hackett-ux-design-thinking/580438/ d/Explains why UX is important t/Business` +
-Adds a single entry with a description and tagged with “Business”
+To add entries to the reading list, please refer to <<Add-Command>>.
 
 ==== Editing an entry: `edit`
 
@@ -707,27 +733,7 @@ Switches to reader view mode with dark style colour scheme
 [[Feeds-Context]]
 === `Feeds` Context Commands
 
-==== Subscribing to a feed: `subscribe` `[since v1.3]`
-
-Adds a feed to the manager and subscribes to updates.
-All entries in the subscribed feed will be added to the reading list.
-
-Format: `subscribe l/URL [ti/TITLE] [d/COMMENT] [t/TAG]...`
-
-[TIP]
-====
-A feed can have any number of tags (including 0)
-====
-
-Examples:
-
-- `subscribe l/https://www.engadget.com/rss.xml ti/Engadget t/Tech` Adds a feed whose name is “Engadget”.
--  The imported entries will be tagged with “Tech” `[coming in v2.0]`
-
-[WARNING]
-====
-The application may be unresponsive for a short while when adding entries from a large feed.
-====
+To subscribe to a feed, please refer to [[Subscribe-Command]].
 
 ==== Updating entries from feeds: `refresh` `[since v1.3]`
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -657,26 +657,21 @@ Format: `clear`
 [[Results-Context]]
 === `Search Results` Context Commands
 
-==== Adding entries: `add` `[since v1.3]`
+==== Adding entries: `addindex` `[since v1.3]`
 
 Adds entries from results to the reading list. Content is automatically downloaded to disk.
 
-Format: `add INDEX`
+Format: `addindex INDEX`
 
-Format: `add INDEX [ti/TITLE_OVERRIDE] [d/DESCRIPTION_OVERRIDE] [t/TAG]...` `[coming in v2.0]`
+Format: `addindex INDEX [ti/TITLE_OVERRIDE] [d/DESCRIPTION_OVERRIDE] [t/TAG]...` `[coming in v2.0]`
 
-Format: `add all` `[coming in v2.0]`
+Format: `addindex all` `[coming in v2.0]`
 
-[TIP]
-====
-A entry can have any number of tags (including 0).
-Title will be automatically filled by parsing the entry if you do not provide it.
-====
 
 Examples:
 
-- `add 3` Adds the 3rd entry.
-- `add 1 d/explains why UX is important t/Business` Adds the 1st entry with a description and tagged with “Business” `[coming in v2.0]`
+- `addindex 3` Adds the 3rd entry.
+- `addindex 1 d/explains why UX is important t/Business` Adds the 1st entry with a description and tagged with “Business” `[coming in v2.0]`
 
 ==== Selecting an entry: `select` `[since v1.3]`
 

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -531,11 +531,11 @@ Switches to a clean and clutter-free reader view mode for a more comfortable rea
 * `view reader s/dark` +
 Switches to reader view mode with dark style colour scheme
 
-==== Redownloading an entry: `redownload` `[coming in v2.0]`
+==== Refreshing an entry: `refresh` `[since v1.3]`
 
-Redownload the specified entry to get the latest version of its content.
+Refreshes the specified entry to get the latest version of its content.
 
-Format: `redownload INDEX`
+Format: `refresh INDEX`
 
 ****
 * Refreshes the content of the entry at the specified `INDEX`.
@@ -546,7 +546,7 @@ Format: `redownload INDEX`
 Examples:
 
 * `list` +
-`redownload 2` +
+`refresh 2` +
 Refreshes the content of the 2nd entry in the reading list.
 
 ==== Marking an entry as read: `read` `[coming in v2.0]`

--- a/src/main/java/seedu/address/logic/commands/AddIndexCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddIndexCommand.java
@@ -15,10 +15,10 @@ import seedu.address.model.entry.Entry;
  * Adds an entry identified using its displayed index to the List context EntryBook.
  * This usage only makes sense in search context.
  */
-public class IndexedAddCommand extends Command {
+public class AddIndexCommand extends Command {
 
-    public static final String COMMAND_WORD = "add";
-    public static final String COMMAND_ALIAS = "a";
+    public static final String COMMAND_WORD = "addindex";
+    public static final String COMMAND_ALIAS = "addi";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds the entry identified by the index number used in the displayed entry list.\n"
@@ -27,7 +27,7 @@ public class IndexedAddCommand extends Command {
 
     private final Index targetIndex;
 
-    public IndexedAddCommand(Index targetIndex) {
+    public AddIndexCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
 
@@ -48,7 +48,7 @@ public class IndexedAddCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof IndexedAddCommand // instanceof handles nulls
-                && targetIndex.equals(((IndexedAddCommand) other).targetIndex)); // state check
+                || (other instanceof AddIndexCommand // instanceof handles nulls
+                && targetIndex.equals(((AddIndexCommand) other).targetIndex)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/BingWebSearchCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BingWebSearchCommand.java
@@ -13,14 +13,14 @@ public class BingWebSearchCommand extends FeedCommand {
 
     public static final String COMMAND_WORD = "bing";
 
-    public BingWebSearchCommand(String keywords) throws UnsupportedEncodingException, MalformedURLException {
-        super(getBingWebSearchRssLink(keywords));
-    }
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Searches the web using Bing. "
+            + "Parameters: [KEYWORDS]\n"
+            + "Example: bing trump";
 
-    private static URL getBingWebSearchRssLink(String keywords)
-            throws UnsupportedEncodingException, MalformedURLException {
-        return new URL(String.format(
-            "https://www.bing.com/search?q=%s&format=rss",
-            URLEncoder.encode(keywords, "UTF-8")));
+    private static final String BING_WEB_SEARCH_RSS_LINK = "https://www.bing.com/search?q=%s&format=rss";
+
+    public BingWebSearchCommand(String keywords) throws UnsupportedEncodingException, MalformedURLException {
+        super(new URL(String.format(BING_WEB_SEARCH_RSS_LINK, URLEncoder.encode(keywords, "UTF-8"))));
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddIndexCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddIndexCommandParser.java
@@ -3,26 +3,26 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.IndexedAddCommand;
+import seedu.address.logic.commands.AddIndexCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
  * Parses the indexed add command.
  */
-public class IndexedAddCommandParser implements Parser<IndexedAddCommand> {
+public class AddIndexCommandParser implements Parser<AddIndexCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the IndexedAddCommand
-     * and returns an IndexedAddCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the AddIndexCommand
+     * and returns an AddIndexCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public IndexedAddCommand parse(String args) throws ParseException {
+    public AddIndexCommand parse(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
-            return new IndexedAddCommand(index);
+            return new AddIndexCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, IndexedAddCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddIndexCommand.MESSAGE_USAGE), pe);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/EntryBookArchivesParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookArchivesParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteArchiveEntryCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UnarchiveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ModelContext;
@@ -38,6 +39,10 @@ public class EntryBookArchivesParser extends EntryBookParser {
 
         case DeleteArchiveEntryCommand.COMMAND_WORD:
             return new DeleteArchiveEntryCommandParser().parse(arguments);
+
+        case SelectCommand.COMMAND_WORD:
+        case SelectCommand.COMMAND_ALIAS:
+            return new SelectCommandParser().parse(arguments);
 
         case UnarchiveCommand.COMMAND_WORD:
         case UnarchiveCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/logic/parser/EntryBookFeedsParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookFeedsParser.java
@@ -8,7 +8,6 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.RefreshFeedCommand;
 import seedu.address.logic.commands.SelectCommand;
-import seedu.address.logic.commands.SubscribeCommand;
 import seedu.address.logic.commands.UnsubscribeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ModelContext;
@@ -37,10 +36,6 @@ public class EntryBookFeedsParser extends EntryBookParser {
         case SelectCommand.COMMAND_WORD:
         case SelectCommand.COMMAND_ALIAS:
             return new SelectCommandParser().parse(arguments);
-
-        case SubscribeCommand.COMMAND_WORD:
-        case SubscribeCommand.COMMAND_ALIAS:
-            return new SubscribeCommandParser().parse(arguments);
 
         case UnsubscribeCommand.COMMAND_WORD:
         case UnsubscribeCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
@@ -4,7 +4,6 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import java.util.regex.Matcher;
 
-import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ArchiveCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
@@ -41,10 +40,6 @@ public class EntryBookListParser extends EntryBookParser {
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
-
-        case AddCommand.COMMAND_WORD:
-        case AddCommand.COMMAND_ALIAS:
-            return new AddCommandParser().parse(arguments);
 
         case ArchiveCommand.COMMAND_WORD:
         case ArchiveCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.RefreshEntryCommand;
+import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.ViewModeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ModelContext;
@@ -62,6 +63,11 @@ public class EntryBookListParser extends EntryBookParser {
         case RefreshEntryCommand.COMMAND_WORD:
         case RefreshEntryCommand.COMMAND_ALIAS:
             return new RefreshEntryCommandParser().parse(arguments);
+
+
+        case SelectCommand.COMMAND_WORD:
+        case SelectCommand.COMMAND_ALIAS:
+            return new SelectCommandParser().parse(arguments);
 
         case ViewModeCommand.COMMAND_WORD:
         case ViewModeCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/logic/parser/EntryBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookParser.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ArchivesCommand;
 import seedu.address.logic.commands.BingWebSearchCommand;
 import seedu.address.logic.commands.Command;
@@ -94,6 +95,10 @@ public abstract class EntryBookParser {
         case HelpCommand.COMMAND_WORD:
         case HelpCommand.COMMAND_ALIAS:
             return new HelpCommand();
+
+        case AddCommand.COMMAND_WORD:
+        case AddCommand.COMMAND_ALIAS:
+            return new AddCommandParser().parse(arguments);
 
         default:
             throw new ParseException(String.format(MESSAGE_UNKNOWN_COMMAND, currentContext));

--- a/src/main/java/seedu/address/logic/parser/EntryBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.SubscribeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ModelContext;
 
@@ -96,9 +97,15 @@ public abstract class EntryBookParser {
         case HelpCommand.COMMAND_ALIAS:
             return new HelpCommand();
 
+        // the following commands are actually context specific but accessible everywhere for convenience
+
         case AddCommand.COMMAND_WORD:
         case AddCommand.COMMAND_ALIAS:
             return new AddCommandParser().parse(arguments);
+
+        case SubscribeCommand.COMMAND_WORD:
+        case SubscribeCommand.COMMAND_ALIAS:
+            return new SubscribeCommandParser().parse(arguments);
 
         default:
             throw new ParseException(String.format(MESSAGE_UNKNOWN_COMMAND, currentContext));

--- a/src/main/java/seedu/address/logic/parser/EntryBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookParser.java
@@ -17,7 +17,6 @@ import seedu.address.logic.commands.GoogleNewsCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.SubscribeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ModelContext;
@@ -75,10 +74,6 @@ public abstract class EntryBookParser {
         case ListCommand.COMMAND_WORD:
         case ListCommand.COMMAND_ALIAS:
             return new ListCommand();
-
-        case SelectCommand.COMMAND_WORD:
-        case SelectCommand.COMMAND_ALIAS:
-            return new SelectCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/EntryBookSearchParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookSearchParser.java
@@ -4,9 +4,9 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import java.util.regex.Matcher;
 
+import seedu.address.logic.commands.AddIndexCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.IndexedAddCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.ViewModeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -30,9 +30,9 @@ public class EntryBookSearchParser extends EntryBookParser {
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
 
-        case IndexedAddCommand.COMMAND_WORD:
-        case IndexedAddCommand.COMMAND_ALIAS:
-            return new IndexedAddCommandParser().parse(arguments);
+        case AddIndexCommand.COMMAND_WORD:
+        case AddIndexCommand.COMMAND_ALIAS:
+            return new AddIndexCommandParser().parse(arguments);
 
         case SelectCommand.COMMAND_WORD:
         case SelectCommand.COMMAND_ALIAS:

--- a/src/test/java/seedu/address/logic/parser/EntryBookFeedsParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookFeedsParserTest.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.parser;
+
+import static org.junit.Assert.assertEquals;
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.logic.commands.RefreshFeedCommand;
+import seedu.address.logic.commands.UnsubscribeCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ModelContext;
+
+public class EntryBookFeedsParserTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final EntryBookFeedsParser parser = new EntryBookFeedsParser();
+
+    @Test
+    public void parseCommand_refresh() throws Exception {
+        RefreshFeedCommand command = (RefreshFeedCommand) parser.parseCommand(
+                RefreshFeedCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new RefreshFeedCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_unsubscribe() throws Exception {
+        UnsubscribeCommand command = (UnsubscribeCommand) parser.parseCommand(
+                UnsubscribeCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new UnsubscribeCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_unsubscribe_alias() throws Exception {
+        UnsubscribeCommand command = (UnsubscribeCommand) parser.parseCommand(
+                UnsubscribeCommand.COMMAND_ALIAS + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new UnsubscribeCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_unknownCommand_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_FEEDS));
+        parser.parseCommand("unknownCommand");
+    }
+
+    @Test
+    public void parseCommand_addindexCommand_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_FEEDS));
+        parser.parseCommand("addindex 9");
+    }
+
+    @Test
+    public void parseCommand_unarchiveCommand_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_FEEDS));
+        parser.parseCommand("unarchive 9");
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
@@ -16,6 +16,7 @@ import org.junit.rules.ExpectedException;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ArchiveCommand;
 import seedu.address.logic.commands.ArchivesCommand;
+import seedu.address.logic.commands.BingWebSearchCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -25,6 +26,7 @@ import seedu.address.logic.commands.FeedCommand;
 import seedu.address.logic.commands.FeedsCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.FindCommand.FindEntryDescriptor;
+import seedu.address.logic.commands.GoogleNewsCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -106,6 +108,20 @@ public class EntryBookListParserTest {
     @Test
     public void parseCommand_feed() throws Exception {
         assertTrue(parser.parseCommand(FeedCommand.COMMAND_WORD + " https://url.com/a.xml") instanceof FeedCommand);
+    }
+
+    @Test
+    public void parseCommand_bing() throws Exception {
+        assertTrue(parser.parseCommand(BingWebSearchCommand.COMMAND_WORD + " somekeyword")
+                instanceof BingWebSearchCommand);
+    }
+
+    @Test
+    public void parseCommand_googlenews() throws Exception {
+        assertTrue(parser.parseCommand(GoogleNewsCommand.COMMAND_WORD) instanceof GoogleNewsCommand);
+        assertTrue(parser.parseCommand(GoogleNewsCommand.COMMAND_ALIAS) instanceof GoogleNewsCommand);
+        assertTrue(parser.parseCommand(GoogleNewsCommand.COMMAND_WORD + " kw") instanceof GoogleNewsCommand);
+        assertTrue(parser.parseCommand(GoogleNewsCommand.COMMAND_ALIAS + " kw") instanceof GoogleNewsCommand);
     }
 
     @Test
@@ -193,5 +209,19 @@ public class EntryBookListParserTest {
         thrown.expect(ParseException.class);
         thrown.expectMessage(String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_LIST));
         parser.parseCommand("unknownCommand");
+    }
+
+    @Test
+    public void parseCommand_unsubscribeCommand_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_LIST));
+        parser.parseCommand("unsubscribe 9");
+    }
+
+    @Test
+    public void parseCommand_unarchiveCommand_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_LIST));
+        parser.parseCommand("unarchive 9");
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EntryBookSearchParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookSearchParserTest.java
@@ -1,0 +1,64 @@
+package seedu.address.logic.parser;
+
+import static org.junit.Assert.assertEquals;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.logic.commands.AddIndexCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.ModelContext;
+
+public class EntryBookSearchParserTest {
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private final EntryBookSearchParser parser = new EntryBookSearchParser();
+
+    @Test
+    public void parseCommand_addindex() throws Exception {
+        AddIndexCommand command = (AddIndexCommand) parser.parseCommand(
+                AddIndexCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new AddIndexCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_addindex_alias() throws Exception {
+        AddIndexCommand command = (AddIndexCommand) parser.parseCommand(
+                AddIndexCommand.COMMAND_ALIAS + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new AddIndexCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_unrecognisedInput_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        parser.parseCommand("");
+    }
+
+    @Test
+    public void parseCommand_unknownCommand_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_SEARCH));
+        parser.parseCommand("unknownCommand");
+    }
+
+    @Test
+    public void parseCommand_otherContextCommand_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_SEARCH));
+        parser.parseCommand("unsubscribe 9");
+    }
+
+    @Test
+    public void parseCommand_unarchiveCommand_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_SEARCH));
+        parser.parseCommand("unarchive 9");
+    }
+}


### PR DESCRIPTION
### Summary of changes

1. promotes `subscribe` to all contexts (closes #153)
2. rename feed context `add` to `addindex` (alias `addi`)
    prevents collision with 3
3. promotes `add` to all contexts
    for consistency with 1
4. `select` command has been lying in multiple (`EntryBookSearchParser` and `EntryBookFeedsParser`) parsers on top of being in the base `EntryBookParser`, so we standardise it by removing the `SelectCommand` reference in `EntryBookParser`.
    rationale is that `select` will behave differently in future versions in feeds context

while here improve some Parser tests,
while here also add help message in `bing` command since it was missing.