### PR TITLE
Add "all" variants of commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAllCommand.java
@@ -3,7 +3,9 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.logging.Logger;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.exceptions.DuplicateEntryCommandException;
@@ -25,6 +27,8 @@ public class AddAllCommand extends Command {
     public static final String MESSAGE_SUCCESS = "All entries added (%s entries)\n"
         + "Some entries may have been skipped if they were already present in the reading list";
 
+    private static final Logger logger = LogsCenter.getLogger(UnarchiveAllCommand.class);
+
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
@@ -37,6 +41,8 @@ public class AddAllCommand extends Command {
                 addCommand.execute(model, history);
                 numAdded++;
             } catch (DuplicateEntryCommandException dece) {
+                logger.warning("Skipping entry which is already in reading list:\n"
+                    + entryToAdd);
                 // Ignore duplicate entry errors
                 // Rethrow other errors
             }

--- a/src/main/java/seedu/address/logic/commands/AddAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAllCommand.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.exceptions.DuplicateEntryCommandException;
+import seedu.address.model.Model;
+import seedu.address.model.entry.Entry;
+
+/**
+ * Adds an entry identified using its displayed index to the List context EntryBook.
+ * This usage only makes sense in search context.
+ */
+public class AddAllCommand extends Command {
+
+    public static final String COMMAND_WORD = "addall";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Adds all entries currently in the displayed entry list.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_SUCCESS = "All entries added (%s entries)\n"
+        + "Some entries may have been skipped if they were already present in the reading list";
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+        List<Entry> lastShownList = model.getFilteredEntryList();
+
+        int numAdded = 0;
+        for (Entry entryToAdd : lastShownList) {
+            Command addCommand = new AddCommand(entryToAdd);
+            try {
+                addCommand.execute(model, history);
+                numAdded++;
+            } catch (DuplicateEntryCommandException dece) {
+                // Ignore duplicate entry errors
+                // Rethrow other errors
+            }
+        }
+        return new CommandResult(String.format(MESSAGE_SUCCESS, numAdded));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || other instanceof AddAllCommand; // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.exceptions.DuplicateEntryCommandException;
 import seedu.address.model.Model;
 import seedu.address.model.entry.Entry;
 import seedu.address.model.entry.exceptions.DuplicateEntryException;
@@ -39,7 +40,6 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "tech";
 
     public static final String MESSAGE_SUCCESS = "New entry added: %1$s";
-    public static final String MESSAGE_DUPLICATE_ENTRY = "This entry already exists in the entry book";
 
     private final Entry toAdd;
 
@@ -68,7 +68,7 @@ public class AddCommand extends Command {
         try {
             model.addListEntry(updatedEntry, articleContent);
         } catch (DuplicateEntryException dee) {
-            throw new CommandException(MESSAGE_DUPLICATE_ENTRY);
+            throw new DuplicateEntryCommandException();
         }
         return new CommandResult(String.format(MESSAGE_SUCCESS, updatedEntry));
     }

--- a/src/main/java/seedu/address/logic/commands/ArchiveAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveAllCommand.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.exceptions.DuplicateEntryCommandException;
+import seedu.address.model.Model;
+import seedu.address.model.entry.Entry;
+
+/**
+ * Archives all entries in the displayed entry list.
+ */
+public class ArchiveAllCommand extends Command {
+
+    public static final String COMMAND_WORD = "archiveall";
+    public static final String COMMAND_ALIAS = "archall";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Archives all entries in the displayed entry list.\n"
+        + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_SUCCESS = "All entries archived: (%s entries)\n"
+        + "Some entries may have been skipped if they were already present in the archives list";
+
+    private static final Logger logger = LogsCenter.getLogger(ArchiveAllCommand.class);
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+        List<Entry> lastShownList = model.getFilteredEntryList();
+        logger.info(String.format("%d", lastShownList.size()));
+
+        int numArchived = 0;
+        for (int i = lastShownList.size(); i > 0; i--) {
+            Command archiveCommand = new ArchiveCommand(Index.fromOneBased(i));
+            try {
+                archiveCommand.execute(model, history);
+                numArchived++;
+            } catch (DuplicateEntryCommandException dece) {
+                logger.info("Skipping duplicate entry at index " + Index.fromOneBased(i));
+                // Ignore duplicate entry errors
+                // Rethrow other errors
+            }
+        }
+        return new CommandResult(String.format(MESSAGE_SUCCESS, numArchived));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof ArchiveAllCommand); // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ArchiveAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveAllCommand.java
@@ -38,12 +38,16 @@ public class ArchiveAllCommand extends Command {
 
         int numArchived = 0;
         for (int i = lastShownList.size(); i > 0; i--) {
-            Command archiveCommand = new ArchiveCommand(Index.fromOneBased(i));
+            Index index = Index.fromOneBased(i);
+            Entry entryToArchive = lastShownList.get(index.getZeroBased());
+            Command archiveCommand = new ArchiveCommand(index);
             try {
                 archiveCommand.execute(model, history);
                 numArchived++;
             } catch (DuplicateEntryCommandException dece) {
-                logger.info("Skipping duplicate entry at index " + Index.fromOneBased(i));
+                logger.warning("Removing duplicate entry at index " + index.getOneBased()
+                    + " which is already in archives list:\n"
+                    + entryToArchive);
                 // Ignore duplicate entry errors
                 // Rethrow other errors
             }

--- a/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ArchiveCommand.java
@@ -8,11 +8,13 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.exceptions.DuplicateEntryCommandException;
 import seedu.address.model.Model;
 import seedu.address.model.entry.Entry;
+import seedu.address.model.entry.exceptions.DuplicateEntryException;
 
 /**
- * Lists all entries in the archives to the user.
+ * Archives an entry in the reading list.
  */
 public class ArchiveCommand extends Command {
 
@@ -41,7 +43,11 @@ public class ArchiveCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
         }
         Entry entryToArchive = lastShownList.get(targetIndex.getZeroBased());
-        model.archiveEntry(entryToArchive);
+        try {
+            model.archiveEntry(entryToArchive);
+        } catch (DuplicateEntryException dee) {
+            throw new DuplicateEntryCommandException();
+        }
         return new CommandResult(String.format(MESSAGE_ARCHIVE_ENTRY_SUCCESS, entryToArchive));
     }
 

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -68,4 +68,8 @@ public class CommandResult {
         return Objects.hash(feedbackToUser, showHelp, exit);
     }
 
+    @Override
+    public String toString() {
+        return "CommandResult: {" + feedbackToUser + "}";
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/RefreshAllEntriesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RefreshAllEntriesCommand.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.entry.Entry;
+
+/**
+ * Refreshes all entries in the displayed entry list.
+ */
+public class RefreshAllEntriesCommand extends Command {
+
+    public static final String COMMAND_WORD = "refreshall";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Refreshes all entries in the displayed entry list.\n"
+            + "May take a while to execute!\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_TRIVIAL_SUCCESS = "No entries to refresh";
+    public static final String MESSAGE_SUCCESS = "Refreshed %d entries";
+    public static final String MESSAGE_PARTIAL_SUCCESS =
+        "Refreshed %d entries, but stopping at entry %d (%s) as it could not be refreshed.\n"
+            + "Please check that the links point to valid websites and that you are connected to the internet.";
+    public static final String MESSAGE_FAILURE =
+        "Stopping as the first entry could not be refreshed.\n"
+            + "Please check that the links point to valid websites and that you are connected to the internet.";
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+
+        List<Entry> filteredEntryList = model.getFilteredEntryList();
+
+        int numEntries = filteredEntryList.size();
+
+        if (numEntries == 0) {
+            return new CommandResult(MESSAGE_TRIVIAL_SUCCESS);
+        }
+
+        int numRefreshed = 0;
+        for (int i = 0; i < numEntries; i++) {
+            Command refreshCommand = new RefreshEntryCommand(Index.fromZeroBased(i));
+            try {
+                refreshCommand.execute(model, history);
+                numRefreshed++;
+            } catch (CommandException ce) {
+                if (i == 0) {
+                    throw new CommandException(MESSAGE_FAILURE);
+                } else {
+                    Entry entryThatCouldNotBeRefreshed = filteredEntryList.get(i);
+                    return new CommandResult(String.format(
+                        MESSAGE_PARTIAL_SUCCESS,
+                        i,
+                        i + 1,
+                        entryThatCouldNotBeRefreshed.getLink()));
+                }
+            }
+        }
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, numRefreshed));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RefreshAllEntriesCommand); // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/RefreshAllFeedsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RefreshAllFeedsCommand.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.entry.Entry;
+
+/**
+ * Refreshes all entries in the displayed entry list.
+ */
+public class RefreshAllFeedsCommand extends Command {
+
+    public static final String COMMAND_WORD = "refreshall";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Refreshes all entries in the displayed entry list.\n"
+            + "May take a while to execute!\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_TRIVIAL_SUCCESS = "No feeds to refresh";
+    public static final String MESSAGE_SUCCESS = "Refreshed %d feeds";
+    public static final String MESSAGE_PARTIAL_SUCCESS =
+        "Refreshed %d feeds, but stopping at feed %d (%s) as it could not be refreshed.\n"
+            + "Please check that the links point to valid feeds and that you are connected to the internet.";
+    public static final String MESSAGE_FAILURE =
+        "Stopping as the first feed could not be refreshed.\n"
+            + "Please check that the links point to valid feeds and that you are connected to the internet.";
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+
+        List<Entry> filteredEntryList = model.getFilteredEntryList();
+
+        int numEntries = filteredEntryList.size();
+
+        if (numEntries == 0) {
+            return new CommandResult(MESSAGE_TRIVIAL_SUCCESS);
+        }
+
+        int numRefreshed = 0;
+        for (int i = 0; i < numEntries; i++) {
+            Command refreshCommand = new RefreshFeedCommand(Index.fromZeroBased(i));
+            try {
+                refreshCommand.execute(model, history);
+                numRefreshed++;
+            } catch (CommandException ce) {
+                if (i == 0) {
+                    throw new CommandException(MESSAGE_FAILURE);
+                } else {
+                    Entry entryThatCouldNotBeRefreshed = filteredEntryList.get(i);
+                    return new CommandResult(String.format(
+                        MESSAGE_PARTIAL_SUCCESS,
+                        i,
+                        i + 1,
+                        entryThatCouldNotBeRefreshed.getLink()));
+                }
+            }
+        }
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, numRefreshed));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof RefreshAllFeedsCommand); // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnarchiveAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveAllCommand.java
@@ -38,12 +38,16 @@ public class UnarchiveAllCommand extends Command {
 
         int numUnarchived = 0;
         for (int i = lastShownList.size(); i > 0; i--) {
-            Command unarchiveCommand = new UnarchiveCommand(Index.fromOneBased(i));
+            Index index = Index.fromOneBased(i);
+            Entry entryToUnarchive = lastShownList.get(index.getZeroBased());
+            Command unarchiveCommand = new UnarchiveCommand(index);
             try {
                 unarchiveCommand.execute(model, history);
                 numUnarchived++;
             } catch (DuplicateEntryCommandException dece) {
-                logger.info("Skipping duplicate entry at index " + Index.fromOneBased(i));
+                logger.warning("Removing duplicate entry at index " + index.getOneBased()
+                    + " which is already in reading list:\n"
+                    + entryToUnarchive);
                 // Ignore duplicate entry errors
                 // Rethrow other errors
             }

--- a/src/main/java/seedu/address/logic/commands/UnarchiveAllCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveAllCommand.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.exceptions.DuplicateEntryCommandException;
+import seedu.address.model.Model;
+import seedu.address.model.entry.Entry;
+
+/**
+ * Archives all entries in the displayed entry list.
+ */
+public class UnarchiveAllCommand extends Command {
+
+    public static final String COMMAND_WORD = "unarchiveall";
+    public static final String COMMAND_ALIAS = "unarchall";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Un-archives all entries in the displayed entry list.\n"
+        + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_SUCCESS = "All entries unarchived: (%s entries)\n"
+        + "Some entries may have been skipped if they were already present in the reading list";
+
+    private static final Logger logger = LogsCenter.getLogger(UnarchiveAllCommand.class);
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) throws CommandException {
+        requireNonNull(model);
+        List<Entry> lastShownList = model.getFilteredEntryList();
+        logger.info(String.format("%d", lastShownList.size()));
+
+        int numUnarchived = 0;
+        for (int i = lastShownList.size(); i > 0; i--) {
+            Command unarchiveCommand = new UnarchiveCommand(Index.fromOneBased(i));
+            try {
+                unarchiveCommand.execute(model, history);
+                numUnarchived++;
+            } catch (DuplicateEntryCommandException dece) {
+                logger.info("Skipping duplicate entry at index " + Index.fromOneBased(i));
+                // Ignore duplicate entry errors
+                // Rethrow other errors
+            }
+        }
+        return new CommandResult(String.format(MESSAGE_SUCCESS, numUnarchived));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof UnarchiveAllCommand); // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnarchiveCommand.java
@@ -9,8 +9,10 @@ import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.exceptions.DuplicateEntryCommandException;
 import seedu.address.model.Model;
 import seedu.address.model.entry.Entry;
+import seedu.address.model.entry.exceptions.DuplicateEntryException;
 import seedu.address.util.Network;
 
 /**
@@ -45,7 +47,11 @@ public class UnarchiveCommand extends Command {
 
         Entry entryToUnarchive = lastShownList.get(targetIndex.getZeroBased());
         Optional<byte[]> articleContent = Network.fetchArticleOptional(entryToUnarchive.getLink().value);
-        model.unarchiveEntry(entryToUnarchive, articleContent);
+        try {
+            model.unarchiveEntry(entryToUnarchive, articleContent);
+        } catch (DuplicateEntryException dee) {
+            throw new DuplicateEntryCommandException();
+        }
         return new CommandResult(String.format(MESSAGE_UNARCHIVE_ENTRY_SUCCESS, entryToUnarchive));
     }
 

--- a/src/main/java/seedu/address/logic/commands/exceptions/DuplicateEntryCommandException.java
+++ b/src/main/java/seedu/address/logic/commands/exceptions/DuplicateEntryCommandException.java
@@ -10,14 +10,4 @@ public class DuplicateEntryCommandException extends CommandException {
         super(MESSAGE_DUPLICATE_ENTRY);
     }
 
-    public DuplicateEntryCommandException(String message) {
-        super(message);
-    }
-
-    /**
-     * Constructs a new {@code CommandException} with the specified detail {@code message} and {@code cause}.
-     */
-    public DuplicateEntryCommandException(String message, Throwable cause) {
-        super(message, cause);
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/exceptions/DuplicateEntryCommandException.java
+++ b/src/main/java/seedu/address/logic/commands/exceptions/DuplicateEntryCommandException.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.commands.exceptions;
+
+/**
+ * Represents an error which occurs during execution of a {@link Command}.
+ */
+public class DuplicateEntryCommandException extends CommandException {
+    public static final String MESSAGE_DUPLICATE_ENTRY = "This entry already exists in the entry book";
+
+    public DuplicateEntryCommandException() {
+        super(MESSAGE_DUPLICATE_ENTRY);
+    }
+
+    public DuplicateEntryCommandException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new {@code CommandException} with the specified detail {@code message} and {@code cause}.
+     */
+    public DuplicateEntryCommandException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/EntryBookArchivesParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookArchivesParser.java
@@ -9,6 +9,7 @@ import seedu.address.logic.commands.DeleteArchiveEntryCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.UnarchiveAllCommand;
 import seedu.address.logic.commands.UnarchiveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ModelContext;
@@ -52,6 +53,10 @@ public class EntryBookArchivesParser extends EntryBookParser {
         case UnarchiveCommand.COMMAND_WORD:
         case UnarchiveCommand.COMMAND_ALIAS:
             return new UnarchiveCommandParser().parse(arguments);
+
+        case UnarchiveAllCommand.COMMAND_WORD:
+        case UnarchiveAllCommand.COMMAND_ALIAS:
+            return new UnarchiveAllCommand();
 
         default:
             return super.parseCommand(userInput, ModelContext.CONTEXT_ARCHIVES);

--- a/src/main/java/seedu/address/logic/parser/EntryBookFeedsParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookFeedsParser.java
@@ -6,6 +6,7 @@ import java.util.regex.Matcher;
 
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.RefreshAllFeedsCommand;
 import seedu.address.logic.commands.RefreshFeedCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UnsubscribeCommand;
@@ -32,6 +33,9 @@ public class EntryBookFeedsParser extends EntryBookParser {
 
         case RefreshFeedCommand.COMMAND_WORD:
             return new RefreshFeedCommandParser().parse(arguments);
+
+        case RefreshAllFeedsCommand.COMMAND_WORD:
+            return new RefreshAllFeedsCommand();
 
         case SelectCommand.COMMAND_WORD:
         case SelectCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import java.util.regex.Matcher;
 
+import seedu.address.logic.commands.ArchiveAllCommand;
 import seedu.address.logic.commands.ArchiveCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
@@ -45,6 +46,10 @@ public class EntryBookListParser extends EntryBookParser {
         case ArchiveCommand.COMMAND_WORD:
         case ArchiveCommand.COMMAND_ALIAS:
             return new ArchiveCommandParser().parse(arguments);
+
+        case ArchiveAllCommand.COMMAND_WORD:
+        case ArchiveAllCommand.COMMAND_ALIAS:
+            return new ArchiveAllCommand();
 
         case EditCommand.COMMAND_WORD:
         case EditCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/logic/parser/EntryBookSearchParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookSearchParser.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import java.util.regex.Matcher;
 
+import seedu.address.logic.commands.AddAllCommand;
 import seedu.address.logic.commands.AddIndexCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.HelpCommand;
@@ -33,6 +34,9 @@ public class EntryBookSearchParser extends EntryBookParser {
         case AddIndexCommand.COMMAND_WORD:
         case AddIndexCommand.COMMAND_ALIAS:
             return new AddIndexCommandParser().parse(arguments);
+
+        case AddAllCommand.COMMAND_WORD:
+            return new AddAllCommand();
 
         case SelectCommand.COMMAND_WORD:
         case SelectCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -73,6 +73,11 @@ public interface Model {
     Path getArticleDataDirectoryPath();
 
     /**
+     * Returns true if the model has an offline copy of the given link.
+     */
+    boolean hasOfflineCopy(URL url);
+
+    /**
      * Returns the link to the offline copy of the url given if it exists.
      */
     Optional<URL> getOfflineLink(URL url);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -165,6 +165,7 @@ public class ModelManager implements Model {
         userPrefs.setArchivesEntryBookFilePath(archivesEntryBookFilePath);
     }
 
+    @Override
     public boolean hasOfflineCopy(URL url) {
         return getOfflineLink(url).isPresent();
     }

--- a/src/test/java/seedu/address/logic/commands/AddAllCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddAllCommandTest.java
@@ -32,7 +32,7 @@ public class AddAllCommandTest {
             commandResult.getFeedbackToUser());
         assertTrue(
             model.getFilteredEntryList().stream()
-                .allMatch(model::hasEntry)
+                .allMatch(model::hasListEntry)
         );
 
         // Executing the command again results in no entries added because they are all duplicates
@@ -43,7 +43,7 @@ public class AddAllCommandTest {
             commandResult.getFeedbackToUser());
         assertTrue(
             model.getFilteredEntryList().stream()
-                .allMatch(model::hasEntry)
+                .allMatch(model::hasListEntry)
         );
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddAllCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddAllCommandTest.java
@@ -1,0 +1,64 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ENTRIES;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.TypicalModelManagerStub;
+import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
+
+public class AddAllCommandTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_allEntriesAddedSuccessfully() throws Exception {
+        Model model = makeTypicalModelInSearchContext();
+
+        CommandResult commandResult = new AddAllCommand().execute(model, commandHistory);
+
+        assertEquals(
+            String.format(AddAllCommand.MESSAGE_SUCCESS, model.getFilteredEntryList().size()),
+            commandResult.getFeedbackToUser());
+        assertTrue(
+            model.getFilteredEntryList().stream()
+                .allMatch(model::hasEntry)
+        );
+
+        // Executing the command again results in no entries added because they are all duplicates
+        commandResult = new AddAllCommand().execute(model, commandHistory);
+
+        assertEquals(
+            String.format(AddAllCommand.MESSAGE_SUCCESS, 0),
+            commandResult.getFeedbackToUser());
+        assertTrue(
+            model.getFilteredEntryList().stream()
+                .allMatch(model::hasEntry)
+        );
+    }
+
+    /**
+     * Creates a new model in the search context with pre-populated entries
+     */
+    @NotNull
+    private Model makeTypicalModelInSearchContext() {
+        Model model = new TypicalModelManagerStub();
+
+        // We need a search entry book for testing purposes
+        model.setSearchEntryBook(model.getArchivesEntryBook());
+        model.setContext(ModelContext.CONTEXT_SEARCH);
+        model.updateFilteredEntryList(PREDICATE_SHOW_ALL_ENTRIES);
+        return model;
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandIntegrationTest.java
@@ -25,6 +25,7 @@ import org.junit.rules.TemporaryFolder;
 
 import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.exceptions.DuplicateEntryCommandException;
 import seedu.address.mocks.TemporaryStorageManager;
 import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.Model;
@@ -84,7 +85,7 @@ public class AddCommandIntegrationTest {
     public void execute_duplicateEntry_throwsCommandException() {
         Entry entryInList = model.getListEntryBook().getEntryList().get(0);
         assertCommandFailure(new AddCommand(entryInList), model, commandHistory,
-                AddCommand.MESSAGE_DUPLICATE_ENTRY);
+                DuplicateEntryCommandException.MESSAGE_DUPLICATE_ENTRY);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -39,7 +39,7 @@ import javafx.beans.property.ReadOnlyProperty;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.CommandHistory;
-import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.commands.exceptions.DuplicateEntryCommandException;
 import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelContext;
@@ -84,8 +84,8 @@ public class AddCommandTest {
         AddCommand addCommand = new AddCommand(validEntry);
         ModelStub modelStub = new ModelStubWithEntry(validEntry);
 
-        thrown.expect(CommandException.class);
-        thrown.expectMessage(AddCommand.MESSAGE_DUPLICATE_ENTRY);
+        thrown.expect(DuplicateEntryCommandException.class);
+        thrown.expectMessage(DuplicateEntryCommandException.MESSAGE_DUPLICATE_ENTRY);
         addCommand.execute(modelStub, commandHistory);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -251,6 +251,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasOfflineCopy(URL url) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public Optional<URL> getOfflineLink(URL url) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/ArchiveAllCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ArchiveAllCommandTest.java
@@ -1,0 +1,50 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.TypicalModelManagerStub;
+import seedu.address.model.Model;
+import seedu.address.testutil.TypicalEntries;
+
+public class ArchiveAllCommandTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_allEntriesArchivedSuccessfully() throws Exception {
+        Model model = new TypicalModelManagerStub();
+
+        int numEntries = model.getFilteredEntryList().size();
+        CommandResult commandResult = new ArchiveAllCommand().execute(model, commandHistory);
+
+        assertEquals(
+            String.format(ArchiveAllCommand.MESSAGE_SUCCESS, numEntries),
+            commandResult.getFeedbackToUser());
+        assertTrue(
+            model.getFilteredEntryList().stream()
+                .allMatch(model::hasEntry)
+        );
+
+        // Executing the command again results in no entries archived because they are all duplicates
+        model.setListEntryBook(TypicalEntries.getTypicalListEntryBook());
+        commandResult = new ArchiveAllCommand().execute(model, commandHistory);
+
+        assertEquals(
+            String.format(ArchiveAllCommand.MESSAGE_SUCCESS, 0),
+            commandResult.getFeedbackToUser());
+        assertTrue(
+            model.getFilteredEntryList().stream()
+                .allMatch(model::hasEntry)
+        );
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/ArchiveAllCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ArchiveAllCommandTest.java
@@ -1,7 +1,11 @@
 package seedu.address.logic.commands;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -10,6 +14,7 @@ import org.junit.rules.ExpectedException;
 import seedu.address.logic.CommandHistory;
 import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.Model;
+import seedu.address.model.entry.Entry;
 import seedu.address.testutil.TypicalEntries;
 
 public class ArchiveAllCommandTest {
@@ -24,27 +29,60 @@ public class ArchiveAllCommandTest {
         Model model = new TypicalModelManagerStub();
 
         int numEntries = model.getFilteredEntryList().size();
-        CommandResult commandResult = new ArchiveAllCommand().execute(model, commandHistory);
+        List<Entry> entriesToArchive = new ArrayList<>(model.getFilteredEntryList());
 
+        assertTrue(
+            entriesToArchive.stream()
+                .noneMatch(model::hasArchivesEntry)
+        );
+        assertTrue(
+            entriesToArchive.stream()
+                .allMatch(model::hasListEntry)
+        );
+        assertFalse(model.getFilteredEntryList().isEmpty());
+
+        CommandResult commandResult = new ArchiveAllCommand().execute(model, commandHistory);
         assertEquals(
             String.format(ArchiveAllCommand.MESSAGE_SUCCESS, numEntries),
             commandResult.getFeedbackToUser());
+
         assertTrue(
-            model.getFilteredEntryList().stream()
-                .allMatch(model::hasEntry)
+            entriesToArchive.stream()
+                .allMatch(model::hasArchivesEntry)
         );
+        assertTrue(
+            entriesToArchive.stream()
+                .noneMatch(model::hasListEntry)
+        );
+        assertTrue(model.getFilteredEntryList().isEmpty());
 
         // Executing the command again results in no entries archived because they are all duplicates
         model.setListEntryBook(TypicalEntries.getTypicalListEntryBook());
-        commandResult = new ArchiveAllCommand().execute(model, commandHistory);
 
+        assertTrue(
+            entriesToArchive.stream()
+                .allMatch(model::hasArchivesEntry)
+        );
+        assertTrue(
+            entriesToArchive.stream()
+                .allMatch(model::hasListEntry)
+        );
+        assertFalse(model.getFilteredEntryList().isEmpty());
+
+        commandResult = new ArchiveAllCommand().execute(model, commandHistory);
         assertEquals(
             String.format(ArchiveAllCommand.MESSAGE_SUCCESS, 0),
             commandResult.getFeedbackToUser());
+
         assertTrue(
-            model.getFilteredEntryList().stream()
-                .allMatch(model::hasEntry)
+            entriesToArchive.stream()
+                .allMatch(model::hasArchivesEntry)
         );
+        assertTrue(
+            entriesToArchive.stream()
+                .noneMatch(model::hasListEntry)
+        );
+        assertTrue(model.getFilteredEntryList().isEmpty());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -17,7 +17,6 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
 import seedu.address.model.entry.Entry;
 import seedu.address.model.entry.EntryContainsSearchTermsPredicate;
 import seedu.address.testutil.EditEntryDescriptorBuilder;
@@ -121,7 +120,8 @@ public class CommandTestUtil {
      * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandHistory, String, Model)}
      * that ignores checking model equality.
      */
-    public static void assertCommandSuccess(Command command, Model actualModel, CommandHistory actualCommandHistory, String expectedMessage) {
+    public static void assertCommandSuccess(Command command, Model actualModel, CommandHistory actualCommandHistory,
+                                            String expectedMessage) {
         assertCommandSuccess(command, actualModel, actualCommandHistory, expectedMessage, actualModel);
     }
 
@@ -133,7 +133,7 @@ public class CommandTestUtil {
      * - {@code actualCommandHistory} remains unchanged.
      */
     public static void assertCommandFailure(Command command, Model actualModel, CommandHistory actualCommandHistory,
-            String expectedMessage) {
+                                            String expectedMessage) {
         // we are unable to defensively copy the model for comparison later, so we can
         // only do so by copying its components.
         EntryBook expectedEntryBook = new EntryBook(actualModel.getListEntryBook());

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -17,6 +17,7 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
 import seedu.address.model.entry.Entry;
 import seedu.address.model.entry.EntryContainsSearchTermsPredicate;
 import seedu.address.testutil.EditEntryDescriptorBuilder;
@@ -114,6 +115,14 @@ public class CommandTestUtil {
             String expectedMessage, Model expectedModel) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, actualCommandHistory, expectedCommandResult, expectedModel);
+    }
+
+    /**
+     * Convenience wrapper to {@link #assertCommandSuccess(Command, Model, CommandHistory, String, Model)}
+     * that ignores checking model equality.
+     */
+    public static void assertCommandSuccess(Command command, Model actualModel, CommandHistory actualCommandHistory, String expectedMessage) {
+        assertCommandSuccess(command, actualModel, actualCommandHistory, expectedMessage, actualModel);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/RefreshAllEntriesCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RefreshAllEntriesCommandTest.java
@@ -1,0 +1,102 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.testutil.TypicalEntries.ALICE;
+import static seedu.address.testutil.TypicalEntries.BROWSER_PANEL_TEST_ENTRY;
+import static seedu.address.testutil.TypicalEntries.WIKIPEDIA_ENTRY;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.mocks.ModelManagerStub;
+import seedu.address.mocks.TemporaryStorageManager;
+import seedu.address.mocks.TypicalModelManagerStub;
+import seedu.address.model.EntryBook;
+import seedu.address.model.Model;
+import seedu.address.testutil.EntryBookBuilder;
+
+public class RefreshAllEntriesCommandTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_allEntriesRefreshedSuccessfully() throws Exception {
+        Model model = makeTestModelWithLocallyLinkedEntries();
+
+        assertTrue(
+            model.getFilteredEntryList().stream()
+                .noneMatch(entry -> model.hasOfflineCopy(entry.getLink().value)));
+        CommandResult commandResult = new RefreshAllEntriesCommand().execute(model, commandHistory);
+
+        assertEquals(
+            String.format(RefreshAllEntriesCommand.MESSAGE_SUCCESS, model.getFilteredEntryList().size()),
+            commandResult.getFeedbackToUser());
+        assertTrue(
+            model.getFilteredEntryList().stream()
+                .allMatch(entry -> model.hasOfflineCopy(entry.getLink().value)));
+    }
+
+    @Test
+    public void execute_someEntriesRefreshedSuccessfully() throws Exception {
+        Model model = makeTestModelWithLocallyLinkedEntries();
+        int numValidLinks = model.getFilteredEntryList().size();
+        model.addListEntry(ALICE, Optional.empty());
+
+        assertTrue(
+            model.getFilteredEntryList().stream()
+                .noneMatch(entry -> model.hasOfflineCopy(entry.getLink().value)));
+        CommandResult commandResult = new RefreshAllEntriesCommand().execute(model, commandHistory);
+
+        assertEquals(String.format(
+            RefreshAllEntriesCommand.MESSAGE_PARTIAL_SUCCESS,
+            numValidLinks,
+            numValidLinks + 1,
+            ALICE.getLink().value),
+            commandResult.getFeedbackToUser());
+        assertTrue(
+            model.getFilteredEntryList().stream()
+                .anyMatch(entry -> model.hasOfflineCopy(entry.getLink().value)));
+    }
+
+    @Test
+    public void execute_noEntriesRefreshedSuccessfully() throws Exception {
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(RefreshAllEntriesCommand.MESSAGE_FAILURE);
+
+        Model model = new TypicalModelManagerStub();
+
+        assertTrue(
+            model.getFilteredEntryList().stream()
+                .noneMatch(entry -> model.hasOfflineCopy(entry.getLink().value)));
+
+        new RefreshAllEntriesCommand().execute(model, commandHistory);
+    }
+
+    /**
+     * Returns a model with entries that are locally linked.
+     */
+    private Model makeTestModelWithLocallyLinkedEntries() throws IOException {
+        Model model = new ModelManagerStub(new TemporaryStorageManager(temporaryFolder));
+        EntryBook testEntryBook = new EntryBookBuilder()
+            .withEntry(WIKIPEDIA_ENTRY)
+            .withEntry(BROWSER_PANEL_TEST_ENTRY)
+            .build();
+        model.setListEntryBook(testEntryBook);
+        return model;
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/RefreshAllEntriesCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RefreshAllEntriesCommandTest.java
@@ -73,7 +73,18 @@ public class RefreshAllEntriesCommandTest {
     }
 
     @Test
-    public void execute_noEntriesRefreshedSuccessfully() throws Exception {
+    public void execute_noEntriesRefreshed_success() throws Exception {
+        Model model = new ModelManagerStub();
+
+        CommandResult commandResult = new RefreshAllEntriesCommand().execute(model, commandHistory);
+
+        assertEquals(
+            RefreshAllEntriesCommand.MESSAGE_TRIVIAL_SUCCESS,
+            commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_firstEntryCannotBeRefreshed_throwsCommandException() throws Exception {
         thrown.expect(CommandException.class);
         thrown.expectMessage(RefreshAllEntriesCommand.MESSAGE_FAILURE);
 

--- a/src/test/java/seedu/address/logic/commands/RefreshAllFeedsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RefreshAllFeedsCommandTest.java
@@ -1,0 +1,116 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.testutil.TypicalEntries.EMPTY_FEED_ENTRY;
+import static seedu.address.testutil.TypicalEntries.NOT_A_FEED_ENTRY;
+import static seedu.address.testutil.TypicalEntries.ONE_ITEM_FEED_ENTRY;
+import static seedu.address.testutil.TypicalEntries.REMOTE_WIKIPEDIA_ENTRY;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.mocks.ModelManagerStub;
+import seedu.address.mocks.TemporaryStorageManager;
+import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
+
+public class RefreshAllFeedsCommandTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_allFeedsRefreshedSuccessfully() throws Exception {
+        Model model = new ModelManagerStub(new TemporaryStorageManager(temporaryFolder));
+        model.setContext(ModelContext.CONTEXT_FEEDS);
+        model.addFeedsEntry(EMPTY_FEED_ENTRY);
+        model.addFeedsEntry(ONE_ITEM_FEED_ENTRY);
+
+        // Check that the wikipedia entry inside ONE_ITEM_FEED_ENTRY has not been added
+        assertFalse(model.hasEntry(REMOTE_WIKIPEDIA_ENTRY));
+
+        CommandResult commandResult = new RefreshAllFeedsCommand().execute(model, commandHistory);
+
+        assertEquals(
+            String.format(RefreshAllFeedsCommand.MESSAGE_SUCCESS, model.getFilteredEntryList().size()),
+            commandResult.getFeedbackToUser());
+
+        // Check that the wikipedia entry inside ONE_ITEM_FEED_ENTRY is now in reading list
+        assertTrue(model.hasEntry(REMOTE_WIKIPEDIA_ENTRY));
+    }
+
+    @Test
+    public void execute_someEntriesRefreshedSuccessfully() throws Exception {
+        Model model = new ModelManagerStub(new TemporaryStorageManager(temporaryFolder));
+        model.setContext(ModelContext.CONTEXT_FEEDS);
+        model.addFeedsEntry(EMPTY_FEED_ENTRY);
+        model.addFeedsEntry(ONE_ITEM_FEED_ENTRY);
+        int numValidLinks = model.getFilteredEntryList().size();
+        model.addFeedsEntry(NOT_A_FEED_ENTRY);
+
+        // Check that the wikipedia entry inside ONE_ITEM_FEED_ENTRY has not been added
+        assertFalse(model.hasEntry(REMOTE_WIKIPEDIA_ENTRY));
+
+        CommandResult commandResult = new RefreshAllFeedsCommand().execute(model, commandHistory);
+
+        assertEquals(String.format(
+            RefreshAllFeedsCommand.MESSAGE_PARTIAL_SUCCESS,
+            numValidLinks,
+            numValidLinks + 1,
+            NOT_A_FEED_ENTRY.getLink().value),
+            commandResult.getFeedbackToUser());
+
+        // Check that the wikipedia entry inside ONE_ITEM_FEED_ENTRY is now added
+        assertTrue(model.hasEntry(REMOTE_WIKIPEDIA_ENTRY));
+    }
+
+    @Test
+    public void execute_someEntriesRefreshedSuccessfully_stopAtFirstError() throws Exception {
+        Model model = new ModelManagerStub(new TemporaryStorageManager(temporaryFolder));
+        model.setContext(ModelContext.CONTEXT_FEEDS);
+        model.addFeedsEntry(EMPTY_FEED_ENTRY);
+        int numValidLinks = model.getFilteredEntryList().size();
+        model.addFeedsEntry(NOT_A_FEED_ENTRY);
+        model.addFeedsEntry(ONE_ITEM_FEED_ENTRY);
+
+        // Check that the wikipedia entry inside ONE_ITEM_FEED_ENTRY has not been added
+        assertFalse(model.hasEntry(REMOTE_WIKIPEDIA_ENTRY));
+
+        CommandResult commandResult = new RefreshAllFeedsCommand().execute(model, commandHistory);
+
+        assertEquals(String.format(
+            RefreshAllFeedsCommand.MESSAGE_PARTIAL_SUCCESS,
+            numValidLinks,
+            numValidLinks + 1,
+            NOT_A_FEED_ENTRY.getLink().value),
+            commandResult.getFeedbackToUser());
+
+        // Check that the wikipedia entry inside ONE_ITEM_FEED_ENTRY has not been added
+        assertFalse(model.hasEntry(REMOTE_WIKIPEDIA_ENTRY));
+    }
+
+    @Test
+    public void execute_noEntriesRefreshedSuccessfully() throws Exception {
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(RefreshAllFeedsCommand.MESSAGE_FAILURE);
+
+        Model model = new ModelManagerStub(new TemporaryStorageManager(temporaryFolder));
+        model.setContext(ModelContext.CONTEXT_FEEDS);
+        model.addFeedsEntry(NOT_A_FEED_ENTRY);
+        model.addFeedsEntry(ONE_ITEM_FEED_ENTRY);
+
+        new RefreshAllFeedsCommand().execute(model, commandHistory);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/RefreshAllFeedsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RefreshAllFeedsCommandTest.java
@@ -101,7 +101,18 @@ public class RefreshAllFeedsCommandTest {
     }
 
     @Test
-    public void execute_noEntriesRefreshedSuccessfully() throws Exception {
+    public void execute_noEntriesRefreshed_success() throws Exception {
+        Model model = new ModelManagerStub();
+
+        CommandResult commandResult = new RefreshAllFeedsCommand().execute(model, commandHistory);
+
+        assertEquals(
+            RefreshAllFeedsCommand.MESSAGE_TRIVIAL_SUCCESS,
+            commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_firstEntryCannotBeRefreshed_throwsCommandException() throws Exception {
         thrown.expect(CommandException.class);
         thrown.expectMessage(RefreshAllFeedsCommand.MESSAGE_FAILURE);
 

--- a/src/test/java/seedu/address/logic/commands/RefreshEntryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RefreshEntryCommandTest.java
@@ -1,0 +1,132 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showEntryAtIndex;
+import static seedu.address.testutil.TypicalEntries.BROWSER_PANEL_TEST_ENTRY;
+import static seedu.address.testutil.TypicalEntries.WIKIPEDIA_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ENTRY;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.ModelManagerStub;
+import seedu.address.mocks.TemporaryStorageManager;
+import seedu.address.model.EntryBook;
+import seedu.address.model.Model;
+import seedu.address.model.entry.Entry;
+import seedu.address.testutil.EntryBookBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code RefreshEntryCommand}.
+ */
+public class RefreshEntryCommandTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private CommandHistory commandHistory = new CommandHistory();
+
+    private Model model;
+
+    @Before
+    public void setup() throws IOException {
+        model = makeTestModelWithLocallyLinkedEntries();
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() throws IOException {
+        RefreshEntryCommand refreshCommand = new RefreshEntryCommand(INDEX_FIRST_ENTRY);
+        Entry entryToRefresh = model.getFilteredEntryList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        URL urlToRefresh = entryToRefresh.getLink().value;
+
+        String expectedMessage = String.format(RefreshEntryCommand.MESSAGE_REFRESH_ENTRY_SUCCESS, INDEX_FIRST_ENTRY.getOneBased());
+
+        assertFalse(model.hasOfflineCopy(urlToRefresh));
+        assertCommandSuccess(refreshCommand, model, commandHistory, expectedMessage);
+        assertTrue(model.hasOfflineCopy(urlToRefresh));
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredEntryList().size() + 1);
+        RefreshEntryCommand refreshCommand = new RefreshEntryCommand(outOfBoundIndex);
+
+        assertCommandFailure(refreshCommand, model, commandHistory, Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showEntryAtIndex(model, INDEX_FIRST_ENTRY);
+
+        RefreshEntryCommand refreshCommand = new RefreshEntryCommand(INDEX_FIRST_ENTRY);
+        Entry entryToRefresh = model.getFilteredEntryList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        URL urlToRefresh = entryToRefresh.getLink().value;
+
+        String expectedMessage = String.format(RefreshEntryCommand.MESSAGE_REFRESH_ENTRY_SUCCESS, INDEX_FIRST_ENTRY.getOneBased());
+
+        assertFalse(model.hasOfflineCopy(urlToRefresh));
+        assertCommandSuccess(refreshCommand, model, commandHistory, expectedMessage);
+        assertTrue(model.hasOfflineCopy(urlToRefresh));
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showEntryAtIndex(model, INDEX_FIRST_ENTRY);
+
+        Index outOfBoundIndex = INDEX_SECOND_ENTRY;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getListEntryBook().getEntryList().size());
+
+        RefreshEntryCommand refreshCommand = new RefreshEntryCommand(outOfBoundIndex);
+
+        assertCommandFailure(refreshCommand, model, commandHistory, Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        RefreshEntryCommand refreshFirstCommand = new RefreshEntryCommand(INDEX_FIRST_ENTRY);
+        RefreshEntryCommand refreshSecondCommand = new RefreshEntryCommand(INDEX_SECOND_ENTRY);
+
+        // same object -> returns true
+        assertTrue(refreshFirstCommand.equals(refreshFirstCommand));
+
+        // same values -> returns true
+        RefreshEntryCommand refreshFirstCommandCopy = new RefreshEntryCommand(INDEX_FIRST_ENTRY);
+        assertTrue(refreshFirstCommand.equals(refreshFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(refreshFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(refreshFirstCommand.equals(null));
+
+        // different entry -> returns false
+        assertFalse(refreshFirstCommand.equals(refreshSecondCommand));
+    }
+
+    /**
+     * Returns a model with entries that are locally linked.
+     */
+    private Model makeTestModelWithLocallyLinkedEntries() throws IOException {
+        Model model = new ModelManagerStub(new TemporaryStorageManager(temporaryFolder));
+        EntryBook testEntryBook = new EntryBookBuilder()
+            .withEntry(WIKIPEDIA_ENTRY)
+            .withEntry(BROWSER_PANEL_TEST_ENTRY)
+            .build();
+        model.setListEntryBook(testEntryBook);
+        return model;
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/RefreshEntryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RefreshEntryCommandTest.java
@@ -52,7 +52,9 @@ public class RefreshEntryCommandTest {
         Entry entryToRefresh = model.getFilteredEntryList().get(INDEX_FIRST_ENTRY.getZeroBased());
         URL urlToRefresh = entryToRefresh.getLink().value;
 
-        String expectedMessage = String.format(RefreshEntryCommand.MESSAGE_REFRESH_ENTRY_SUCCESS, INDEX_FIRST_ENTRY.getOneBased());
+        String expectedMessage = String.format(
+            RefreshEntryCommand.MESSAGE_REFRESH_ENTRY_SUCCESS,
+            INDEX_FIRST_ENTRY.getOneBased());
 
         assertFalse(model.hasOfflineCopy(urlToRefresh));
         assertCommandSuccess(refreshCommand, model, commandHistory, expectedMessage);
@@ -75,7 +77,9 @@ public class RefreshEntryCommandTest {
         Entry entryToRefresh = model.getFilteredEntryList().get(INDEX_FIRST_ENTRY.getZeroBased());
         URL urlToRefresh = entryToRefresh.getLink().value;
 
-        String expectedMessage = String.format(RefreshEntryCommand.MESSAGE_REFRESH_ENTRY_SUCCESS, INDEX_FIRST_ENTRY.getOneBased());
+        String expectedMessage = String.format(
+            RefreshEntryCommand.MESSAGE_REFRESH_ENTRY_SUCCESS,
+            INDEX_FIRST_ENTRY.getOneBased());
 
         assertFalse(model.hasOfflineCopy(urlToRefresh));
         assertCommandSuccess(refreshCommand, model, commandHistory, expectedMessage);

--- a/src/test/java/seedu/address/logic/commands/RefreshEntryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RefreshEntryCommandTest.java
@@ -42,7 +42,7 @@ public class RefreshEntryCommandTest {
     private Model model;
 
     @Before
-    public void setup() throws IOException {
+    public void setUp() throws IOException {
         model = makeTestModelWithLocallyLinkedEntries();
     }
 

--- a/src/test/java/seedu/address/logic/commands/UnarchiveAllCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnarchiveAllCommandTest.java
@@ -1,7 +1,11 @@
 package seedu.address.logic.commands;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -11,6 +15,7 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.Model;
 import seedu.address.model.ModelContext;
+import seedu.address.model.entry.Entry;
 import seedu.address.testutil.TypicalEntries;
 
 public class UnarchiveAllCommandTest {
@@ -26,27 +31,60 @@ public class UnarchiveAllCommandTest {
         model.setContext(ModelContext.CONTEXT_ARCHIVES);
 
         int numEntries = model.getFilteredEntryList().size();
-        CommandResult commandResult = new UnarchiveAllCommand().execute(model, commandHistory);
+        List<Entry> entriesToArchive = new ArrayList<>(model.getFilteredEntryList());
 
+        assertTrue(
+            entriesToArchive.stream()
+                .allMatch(model::hasArchivesEntry)
+        );
+        assertTrue(
+            entriesToArchive.stream()
+                .noneMatch(model::hasListEntry)
+        );
+        assertFalse(model.getFilteredEntryList().isEmpty());
+
+        CommandResult commandResult = new UnarchiveAllCommand().execute(model, commandHistory);
         assertEquals(
             String.format(UnarchiveAllCommand.MESSAGE_SUCCESS, numEntries),
             commandResult.getFeedbackToUser());
+
         assertTrue(
-            model.getFilteredEntryList().stream()
-                .allMatch(model::hasEntry)
+            entriesToArchive.stream()
+                .allMatch(model::hasListEntry)
         );
+        assertTrue(
+            entriesToArchive.stream()
+                .noneMatch(model::hasArchivesEntry)
+        );
+        assertTrue(model.getFilteredEntryList().isEmpty());
 
         // Executing the command again results in no entries un-archived because they are all duplicates
         model.setArchivesEntryBook(TypicalEntries.getTypicalArchivesEntryBook());
-        commandResult = new UnarchiveAllCommand().execute(model, commandHistory);
 
+        assertTrue(
+            entriesToArchive.stream()
+                .allMatch(model::hasArchivesEntry)
+        );
+        assertTrue(
+            entriesToArchive.stream()
+                .allMatch(model::hasListEntry)
+        );
+        assertFalse(model.getFilteredEntryList().isEmpty());
+
+        commandResult = new UnarchiveAllCommand().execute(model, commandHistory);
         assertEquals(
             String.format(UnarchiveAllCommand.MESSAGE_SUCCESS, 0),
             commandResult.getFeedbackToUser());
+
         assertTrue(
-            model.getFilteredEntryList().stream()
-                .allMatch(model::hasEntry)
+            entriesToArchive.stream()
+                .allMatch(model::hasListEntry)
         );
+        assertTrue(
+            entriesToArchive.stream()
+                .noneMatch(model::hasArchivesEntry)
+        );
+        assertTrue(model.getFilteredEntryList().isEmpty());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/UnarchiveAllCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnarchiveAllCommandTest.java
@@ -1,0 +1,52 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.TypicalModelManagerStub;
+import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
+import seedu.address.testutil.TypicalEntries;
+
+public class UnarchiveAllCommandTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_allEntriesUnarchivedSuccessfully() throws Exception {
+        Model model = new TypicalModelManagerStub();
+        model.setContext(ModelContext.CONTEXT_ARCHIVES);
+
+        int numEntries = model.getFilteredEntryList().size();
+        CommandResult commandResult = new UnarchiveAllCommand().execute(model, commandHistory);
+
+        assertEquals(
+            String.format(UnarchiveAllCommand.MESSAGE_SUCCESS, numEntries),
+            commandResult.getFeedbackToUser());
+        assertTrue(
+            model.getFilteredEntryList().stream()
+                .allMatch(model::hasEntry)
+        );
+
+        // Executing the command again results in no entries un-archived because they are all duplicates
+        model.setArchivesEntryBook(TypicalEntries.getTypicalArchivesEntryBook());
+        commandResult = new UnarchiveAllCommand().execute(model, commandHistory);
+
+        assertEquals(
+            String.format(UnarchiveAllCommand.MESSAGE_SUCCESS, 0),
+            commandResult.getFeedbackToUser());
+        assertTrue(
+            model.getFilteredEntryList().stream()
+                .allMatch(model::hasEntry)
+        );
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/EntryBookArchivesParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookArchivesParserTest.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.UnarchiveAllCommand;
 import seedu.address.logic.commands.UnarchiveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ModelContext;
@@ -66,6 +67,16 @@ public class EntryBookArchivesParserTest {
         UnarchiveCommand command = (UnarchiveCommand) parser.parseCommand(
             UnarchiveCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
         assertEquals(new UnarchiveCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_unarchiveall() throws Exception {
+        UnarchiveAllCommand command = (UnarchiveAllCommand) parser.parseCommand(
+            UnarchiveAllCommand.COMMAND_WORD);
+        assertEquals(new UnarchiveAllCommand(), command);
+        command = (UnarchiveAllCommand) parser.parseCommand(
+            UnarchiveAllCommand.COMMAND_ALIAS);
+        assertEquals(new UnarchiveAllCommand(), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EntryBookFeedsParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookFeedsParserTest.java
@@ -8,6 +8,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import seedu.address.logic.commands.RefreshAllFeedsCommand;
 import seedu.address.logic.commands.RefreshFeedCommand;
 import seedu.address.logic.commands.UnsubscribeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -24,6 +25,13 @@ public class EntryBookFeedsParserTest {
         RefreshFeedCommand command = (RefreshFeedCommand) parser.parseCommand(
                 RefreshFeedCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
         assertEquals(new RefreshFeedCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_refreshall() throws Exception {
+        RefreshAllFeedsCommand command = (RefreshAllFeedsCommand) parser.parseCommand(
+            RefreshAllFeedsCommand.COMMAND_WORD);
+        assertEquals(new RefreshAllFeedsCommand(), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ArchiveAllCommand;
 import seedu.address.logic.commands.ArchiveCommand;
 import seedu.address.logic.commands.ArchivesCommand;
 import seedu.address.logic.commands.BingWebSearchCommand;
@@ -64,6 +65,19 @@ public class EntryBookListParserTest {
         ArchiveCommand command = (ArchiveCommand) parser.parseCommand(
             ArchiveCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
         assertEquals(new ArchiveCommand(INDEX_FIRST_ENTRY), command);
+        command = (ArchiveCommand) parser.parseCommand(
+            ArchiveCommand.COMMAND_ALIAS + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new ArchiveCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_archiveall() throws Exception {
+        ArchiveAllCommand command = (ArchiveAllCommand) parser.parseCommand(
+            ArchiveAllCommand.COMMAND_WORD);
+        assertEquals(new ArchiveAllCommand(), command);
+        command = (ArchiveAllCommand) parser.parseCommand(
+            ArchiveAllCommand.COMMAND_ALIAS);
+        assertEquals(new ArchiveAllCommand(), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EntryBookSearchParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookSearchParserTest.java
@@ -9,6 +9,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import seedu.address.logic.commands.AddAllCommand;
 import seedu.address.logic.commands.AddIndexCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -32,6 +33,13 @@ public class EntryBookSearchParserTest {
         AddIndexCommand command = (AddIndexCommand) parser.parseCommand(
                 AddIndexCommand.COMMAND_ALIAS + " " + INDEX_FIRST_ENTRY.getOneBased());
         assertEquals(new AddIndexCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_addall() throws Exception {
+        AddAllCommand command = (AddAllCommand) parser.parseCommand(
+            AddAllCommand.COMMAND_WORD);
+        assertEquals(new AddAllCommand(), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/mocks/ModelManagerStub.java
+++ b/src/test/java/seedu/address/mocks/ModelManagerStub.java
@@ -3,6 +3,7 @@ package seedu.address.mocks;
 import seedu.address.model.EntryBook;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.storage.Storage;
 
 /**
  * A mock to create an empty ModelManager for testing purposes
@@ -11,6 +12,10 @@ public class ModelManagerStub extends ModelManager {
 
     public ModelManagerStub() {
         super(new EntryBook(), new EntryBook(), new EntryBook(), new UserPrefs(), new StorageStub());
+    }
+
+    public ModelManagerStub(Storage storage) {
+        super(new EntryBook(), new EntryBook(), new EntryBook(), new UserPrefs(), storage);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalEntries.java
+++ b/src/test/java/seedu/address/testutil/TypicalEntries.java
@@ -320,6 +320,11 @@ public class TypicalEntries {
             .withDescription("Wikipedia test web page")
             .withLink(MainApp.class.getResource("/view/BrowserPanelTest/wikipedia.html"))
             .build();
+    public static final Entry REMOTE_WIKIPEDIA_ENTRY = new EntryBuilder()
+        .withTitle("Wikipedia Test Web Page")
+        .withDescription("Wikipedia test web page")
+        .withLink(WIKIPEDIA_ENTRY_BASE_URL)
+        .build();
 
     // bunch of RSS feeds
     public static final Entry KATTIS_FEED_ENTRY = new EntryBuilder()
@@ -328,11 +333,29 @@ public class TypicalEntries {
             .withLink("https://open.kattis.com/rss/new-problems")
             .build();
 
+    public static final Entry EMPTY_FEED_ENTRY = new EntryBuilder()
+        .withTitle("An empty feed")
+        .withDescription("Very empty feed")
+        .withLink(MainApp.class.getResource("/RssFeedTest/emptyrss.xml"))
+        .build();
+
+    public static final Entry ONE_ITEM_FEED_ENTRY = new EntryBuilder()
+        .withTitle("One item feed")
+        .withDescription("Almost empty feed")
+        .withLink(MainApp.class.getResource("/RssFeedTest/oneitemrss.xml"))
+        .build();
+
     public static final Entry LOCAL_FEED_ENTRY = new EntryBuilder()
             .withTitle("Tsutsukakushi's anime reviews - local copy")
             .withDescription("anime reviews")
             .withLink(MainApp.class.getResource("/RssFeedTest/rss.xml"))
             .build();
+
+    public static final Entry NOT_A_FEED_ENTRY = new EntryBuilder()
+        .withTitle("Not a feed")
+        .withDescription("Not a feed")
+        .withLink(MainApp.class.getResource("/RssFeedTest/notafeed.notxml"))
+        .build();
 
     public static final Entry ANIMEREVIEW_FEED_ENTRY = new EntryBuilder()
             .withTitle("Tsutsukakushi's anime reviews - remote mirror")

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.exceptions.DuplicateEntryCommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelContext;
 import seedu.address.model.entry.Description;
@@ -107,21 +108,21 @@ public class AddCommandSystemTest extends EntryBookSystemTest {
 
         /* Case: add a duplicate entry -> rejected */
         command = EntryUtil.getAddCommand(HOON);
-        assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_ENTRY);
+        assertCommandFailure(command, DuplicateEntryCommandException.MESSAGE_DUPLICATE_ENTRY);
 
         /* Case: add a duplicate entry except with different description -> rejected */
         toAdd = new EntryBuilder(HOON).withDescription(VALID_DESCRIPTION_BOB).build();
         command = EntryUtil.getAddCommand(toAdd);
-        assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_ENTRY);
+        assertCommandFailure(command, DuplicateEntryCommandException.MESSAGE_DUPLICATE_ENTRY);
 
         /* Case: add a duplicate entry except with different title -> rejected */
         toAdd = new EntryBuilder(HOON).withTitle(VALID_TITLE_BOB).build();
         command = EntryUtil.getAddCommand(toAdd);
-        assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_ENTRY);
+        assertCommandFailure(command, DuplicateEntryCommandException.MESSAGE_DUPLICATE_ENTRY);
 
         /* Case: add a duplicate entry except with different tags -> rejected */
         command = EntryUtil.getAddCommand(HOON) + " " + PREFIX_TAG.getPrefix() + "friends";
-        assertCommandFailure(command, AddCommand.MESSAGE_DUPLICATE_ENTRY);
+        assertCommandFailure(command, DuplicateEntryCommandException.MESSAGE_DUPLICATE_ENTRY);
 
         /* Case: missing link -> rejected */
         command = AddCommand.COMMAND_WORD + TITLE_DESC_AMY + DESCRIPTION_DESC_AMY;

--- a/src/test/resources/RssFeedTest/emptyrss.xml
+++ b/src/test/resources/RssFeedTest/emptyrss.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+
+<channel>
+<title>An empty feed</title>
+<link>https://empty.feed/</link>
+<description>
+Very empty feed
+</description>
+<lastBuildDate>Sun May 27 04:15:47 EEST 2018</lastBuildDate>
+</channel>
+</rss>

--- a/src/test/resources/RssFeedTest/oneitemrss.xml
+++ b/src/test/resources/RssFeedTest/oneitemrss.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+
+<channel>
+<title>One item feed</title>
+<link>https://one.item.feed/</link>
+<description>
+Almost empty feed
+</description>
+<lastBuildDate>Sun May 27 04:15:47 EEST 2018</lastBuildDate>
+<item>
+<title>The only item in this feed</title>
+<link>http://en.wikipedia.org/wiki/Therapsids</link>
+<pubDate>Wed Jan 10 03:01:02 2018 +0200</pubDate>
+<description><![CDATA[
+Wikipedia
+]]></description>
+</item>
+</channel>
+</rss>


### PR DESCRIPTION
Depends on #191.
Resolves #169.

Adds "all" variants such as `addall`, `refreshall`, `archiveall`, etc.

### Summary of changes:
- Refactor DuplicateEntryCommandException to own class so it can be detected during addall operation
- Add `addall` and tests
- Add `archiveall` and tests
- Add tests for `refresh`
- Add `refreshall` and tests
- Add `unarchiveall` and tests