### PR TITLE
Add tests for parsers

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -27,7 +27,7 @@ import seedu.address.model.tag.Tag;
 /**
  * Contains utility methods used for parsing strings in the various *Parser classes.
  */
-public class ParserUtil {
+public abstract class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
 

--- a/src/test/java/seedu/address/logic/parser/AddIndexCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddIndexCommandParserTest.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.AddIndexCommand;
+
+/**
+ * Test scope: similar to {@code DeleteCommandParserTest}.
+ * @see DeleteCommandParserTest
+ */
+public class AddIndexCommandParserTest {
+
+    private AddIndexCommandParser parser = new AddIndexCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsAddIndexCommand() {
+        assertParseSuccess(parser, "1", new AddIndexCommand(INDEX_FIRST_ENTRY));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddIndexCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/BingWebSearchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/BingWebSearchCommandParserTest.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.parser;
+
+import static org.junit.Assert.assertEquals;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.address.logic.commands.BingWebSearchCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class BingWebSearchCommandParserTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private BingWebSearchCommandParser parser = new BingWebSearchCommandParser();
+
+    @Test
+    public void parse_validArgs_success() throws ParseException, UnsupportedEncodingException, MalformedURLException {
+        assertEquals(new BingWebSearchCommand("1"), parser.parse("1"));
+    }
+
+    @Test
+    public void parse_argsAreTrimmed() throws ParseException {
+        assertEquals(parser.parse("1"), parser.parse(" 1 "));
+    }
+
+    @Test
+    public void parse_emptyArgs_throwsParseException() throws ParseException {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, BingWebSearchCommand.MESSAGE_USAGE));
+        parser.parse("");
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/DeleteArchiveEntryCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteArchiveEntryCommandParserTest.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.DeleteArchiveEntryCommand;
+
+/**
+ * Test scope: similar to {@code DeleteCommandParserTest}.
+ * @see DeleteCommandParserTest
+ */
+public class DeleteArchiveEntryCommandParserTest {
+
+    private DeleteArchiveEntryCommandParser parser = new DeleteArchiveEntryCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsDeleteArchiveEntryCommand() {
+        assertParseSuccess(parser, "1", new DeleteArchiveEntryCommand(INDEX_FIRST_ENTRY));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteArchiveEntryCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/EntryBookArchivesParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookArchivesParserTest.java
@@ -10,10 +10,12 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import seedu.address.logic.commands.DeleteArchiveEntryCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UnarchiveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ModelContext;
@@ -23,6 +25,13 @@ public class EntryBookArchivesParserTest {
     public ExpectedException thrown = ExpectedException.none();
 
     private final EntryBookArchivesParser parser = new EntryBookArchivesParser();
+
+    @Test
+    public void parseCommand_emptyString_throwsParseException() throws ParseException {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        parser.parseCommand("");
+    }
 
     @Test
     public void parseCommand_exit() throws Exception {
@@ -66,6 +75,27 @@ public class EntryBookArchivesParserTest {
         UnarchiveCommand command = (UnarchiveCommand) parser.parseCommand(
             UnarchiveCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
         assertEquals(new UnarchiveCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_select() throws Exception {
+        SelectCommand command = (SelectCommand) parser.parseCommand(
+            SelectCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new SelectCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_select_alias() throws Exception {
+        SelectCommand command = (SelectCommand) parser.parseCommand(
+            SelectCommand.COMMAND_ALIAS + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new SelectCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_deleteArchiveEntry() throws Exception {
+        DeleteArchiveEntryCommand command = (DeleteArchiveEntryCommand) parser.parseCommand(
+            DeleteArchiveEntryCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new DeleteArchiveEntryCommand(INDEX_FIRST_ENTRY), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EntryBookFeedsParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookFeedsParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static org.junit.Assert.assertEquals;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
 
@@ -8,7 +9,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.RefreshFeedCommand;
+import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UnsubscribeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ModelContext;
@@ -20,10 +23,31 @@ public class EntryBookFeedsParserTest {
     private final EntryBookFeedsParser parser = new EntryBookFeedsParser();
 
     @Test
+    public void parseCommand_emptyString_throwsParseException() throws ParseException {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        parser.parseCommand("");
+    }
+
+    @Test
     public void parseCommand_refresh() throws Exception {
         RefreshFeedCommand command = (RefreshFeedCommand) parser.parseCommand(
                 RefreshFeedCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
         assertEquals(new RefreshFeedCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_select() throws Exception {
+        SelectCommand command = (SelectCommand) parser.parseCommand(
+            SelectCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new SelectCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_select_alias() throws Exception {
+        SelectCommand command = (SelectCommand) parser.parseCommand(
+            SelectCommand.COMMAND_ALIAS + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new SelectCommand(INDEX_FIRST_ENTRY), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
@@ -30,7 +30,9 @@ import seedu.address.logic.commands.GoogleNewsCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.RefreshEntryCommand;
 import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.SubscribeCommand;
 import seedu.address.logic.commands.ViewModeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ModelContext;
@@ -178,6 +180,13 @@ public class EntryBookListParserTest {
     }
 
     @Test
+    public void parseCommand_refresh() throws Exception {
+        RefreshEntryCommand command = (RefreshEntryCommand) parser.parseCommand(
+            RefreshEntryCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new RefreshEntryCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
     public void parseCommand_select() throws Exception {
         SelectCommand command = (SelectCommand) parser.parseCommand(
                 SelectCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
@@ -195,6 +204,17 @@ public class EntryBookListParserTest {
         ViewModeCommand aliasCommand = (ViewModeCommand) parser.parseCommand(
                 ViewModeCommand.COMMAND_ALIAS + " " + VALID_VIEWTYPE_READER + STYLE_DESC_DARK);
         assertEquals(new ViewModeCommand(new ViewMode(ViewType.READER, ReaderViewStyle.DARK)), aliasCommand);
+    }
+
+    @Test
+    public void parseCommand_subscribe() throws Exception {
+        Entry entry = new EntryBuilder().build();
+        SubscribeCommand command = (SubscribeCommand) parser.parseCommand(
+            SubscribeCommand.COMMAND_WORD + " " + EntryUtil.getEntryDetails(entry));
+        assertEquals(new SubscribeCommand(entry), command);
+        SubscribeCommand commandAlias = (SubscribeCommand) parser.parseCommand(
+            SubscribeCommand.COMMAND_ALIAS + " " + EntryUtil.getEntryDetails(entry));
+        assertEquals(new SubscribeCommand(entry), commandAlias);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EntryBookSearchParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookSearchParserTest.java
@@ -3,6 +3,9 @@ package seedu.address.logic.parser;
 import static org.junit.Assert.assertEquals;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.STYLE_DESC_DARK;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_VIEWTYPE_BROWSER;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_VIEWTYPE_READER;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
 
 import org.junit.Rule;
@@ -11,14 +14,26 @@ import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.commands.AddIndexCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.SelectCommand;
+import seedu.address.logic.commands.ViewModeCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ModelContext;
+import seedu.address.ui.ReaderViewStyle;
+import seedu.address.ui.ViewMode;
+import seedu.address.ui.ViewType;
 
 public class EntryBookSearchParserTest {
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
     private final EntryBookSearchParser parser = new EntryBookSearchParser();
+
+    @Test
+    public void parseCommand_emptyString_throwsParseException() throws ParseException {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+        parser.parseCommand("");
+    }
 
     @Test
     public void parseCommand_addindex() throws Exception {
@@ -35,10 +50,34 @@ public class EntryBookSearchParserTest {
     }
 
     @Test
+    public void parseCommand_select() throws Exception {
+        SelectCommand command = (SelectCommand) parser.parseCommand(
+            SelectCommand.COMMAND_WORD + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new SelectCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
+    public void parseCommand_select_alias() throws Exception {
+        SelectCommand command = (SelectCommand) parser.parseCommand(
+            SelectCommand.COMMAND_ALIAS + " " + INDEX_FIRST_ENTRY.getOneBased());
+        assertEquals(new SelectCommand(INDEX_FIRST_ENTRY), command);
+    }
+
+    @Test
     public void parseCommand_unrecognisedInput_throwsParseException() throws Exception {
         thrown.expect(ParseException.class);
         thrown.expectMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         parser.parseCommand("");
+    }
+
+    @Test
+    public void parseCommand_view() throws Exception {
+        ViewModeCommand command = (ViewModeCommand) parser.parseCommand(
+            ViewModeCommand.COMMAND_WORD + " " + VALID_VIEWTYPE_BROWSER);
+        assertEquals(new ViewModeCommand(new ViewMode(ViewType.BROWSER)), command);
+        ViewModeCommand aliasCommand = (ViewModeCommand) parser.parseCommand(
+            ViewModeCommand.COMMAND_ALIAS + " " + VALID_VIEWTYPE_READER + STYLE_DESC_DARK);
+        assertEquals(new ViewModeCommand(new ViewMode(ViewType.READER, ReaderViewStyle.DARK)), aliasCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/GoogleNewsCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/GoogleNewsCommandParserTest.java
@@ -1,0 +1,31 @@
+package seedu.address.logic.parser;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.GoogleNewsCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class GoogleNewsCommandParserTest {
+
+    private GoogleNewsCommandParser parser = new GoogleNewsCommandParser();
+
+    @Test
+    public void parse_validArgs_success() throws ParseException, UnsupportedEncodingException, MalformedURLException {
+        assertEquals(new GoogleNewsCommand("1"), parser.parse("1"));
+    }
+
+    @Test
+    public void parse_argsAreTrimmed() throws ParseException {
+        assertEquals(parser.parse("1"), parser.parse(" 1 "));
+    }
+
+    @Test
+    public void parse_emptyArgs_returnsDefaultGoogleNewsCommand() throws ParseException, MalformedURLException {
+        assertEquals(new GoogleNewsCommand(), parser.parse(""));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -51,10 +51,29 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseIndex_outOfRangeInput_throwsParseException() throws Exception {
+    public void parseIndex_invalidInputNonNumeric_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        ParserUtil.parseIndex("abc");
+    }
+
+    @Test
+    public void parseIndex_invalidInputOnlyDecimal_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        ParserUtil.parseIndex("0x1");
+    }
+
+    @Test
+    public void parseIndex_outOfRangeInputTooBig_throwsParseException() throws Exception {
         thrown.expect(ParseException.class);
         thrown.expectMessage(MESSAGE_INVALID_INDEX);
-        ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1));
+        ParserUtil.parseIndex(Long.toString(((long) Integer.MAX_VALUE) + 1));
+    }
+
+    @Test
+    public void parseIndex_outOfRangeInputNegative_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(MESSAGE_INVALID_INDEX);
+        ParserUtil.parseIndex("-1");
     }
 
     @Test
@@ -123,38 +142,6 @@ public class ParserUtilTest {
         Description expectedDescription = new Description(VALID_COMMENT);
         assertEquals(expectedDescription, ParserUtil.parseDescription(Optional.of(descriptionWithWhitespace)));
     }
-
-    // No longer valid with the optionality of the (invisible) address field
-    /*
-    @Test
-    public void parseAddress_null_throwsNullPointerException() {
-        Assert.assertThrows(NullPointerException.class, () -> ParserUtil.parseAddress((String) null));
-    }
-
-    @Test
-    public void parseAddress_invalidValue_throwsParseException() {
-        Assert.assertThrows(ParseException.class, () -> ParserUtil.parseAddress(INVALID_ADDRESS));
-    }
-
-    @Test
-    public void parseAddress_emptyValue_returnsDefaultAddress() throws Exception {
-        Address expectedAddress = new Address(Address.DEFAULT_ADDRESS);
-        assertEquals(expectedAddress, ParserUtil.parseAddress(Optional.empty()));
-    }
-
-    @Test
-    public void parseAddress_validValueWithoutWhitespace_returnsAddress() throws Exception {
-        Address expectedAddress = new Address(VALID_ADDRESS);
-        assertEquals(expectedAddress, ParserUtil.parseAddress(VALID_ADDRESS));
-    }
-
-    @Test
-    public void parseAddress_validValueWithWhitespace_returnsTrimmedAddress() throws Exception {
-        String addressWithWhitespace = WHITESPACE + VALID_ADDRESS + WHITESPACE;
-        Address expectedAddress = new Address(VALID_ADDRESS);
-        assertEquals(expectedAddress, ParserUtil.parseAddress(addressWithWhitespace));
-    }
-    */
 
     @Test
     public void parseLink_null_throwsNullPointerException() {

--- a/src/test/java/seedu/address/logic/parser/RefreshEntryCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RefreshEntryCommandParserTest.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.RefreshEntryCommand;
+
+/**
+ * Test scope: similar to {@code DeleteCommandParserTest}.
+ * @see DeleteCommandParserTest
+ */
+public class RefreshEntryCommandParserTest {
+
+    private RefreshEntryCommandParser parser = new RefreshEntryCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsRefreshEntryCommand() {
+        assertParseSuccess(parser, "1", new RefreshEntryCommand(INDEX_FIRST_ENTRY));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, RefreshEntryCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/RefreshFeedCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/RefreshFeedCommandParserTest.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.RefreshFeedCommand;
+
+/**
+ * Test scope: similar to {@code DeleteCommandParserTest}.
+ * @see DeleteCommandParserTest
+ */
+public class RefreshFeedCommandParserTest {
+
+    private RefreshFeedCommandParser parser = new RefreshFeedCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsRefreshFeedCommand() {
+        assertParseSuccess(parser, "1", new RefreshFeedCommand(INDEX_FIRST_ENTRY));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, RefreshFeedCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/SubscribeCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SubscribeCommandParserTest.java
@@ -1,0 +1,120 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.DESCRIPTION_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DESCRIPTION;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DESCRIPTION_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_LINK;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_LINK_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TITLE;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TITLE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LINK_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.LINK_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
+import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_SCIENCE;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_TECH;
+import static seedu.address.logic.commands.CommandTestUtil.TITLE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.TITLE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DESCRIPTION_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LINK_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_SCIENCE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_TECH;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TITLE_BOB;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalEntries.AMY;
+import static seedu.address.testutil.TypicalEntries.BOB;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.SubscribeCommand;
+import seedu.address.model.entry.Description;
+import seedu.address.model.entry.Entry;
+import seedu.address.model.entry.Link;
+import seedu.address.model.entry.Title;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.EntryBuilder;
+
+public class SubscribeCommandParserTest {
+    private SubscribeCommandParser parser = new SubscribeCommandParser();
+
+    @Test
+    public void parse_allFieldsPresent_success() {
+        Entry expectedEntry = new EntryBuilder(BOB).withTags(VALID_TAG_TECH).build();
+
+        // whitespace only preamble
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
+                + TAG_DESC_TECH, new SubscribeCommand(expectedEntry));
+
+        // multiple titles - last title accepted
+        assertParseSuccess(parser, TITLE_DESC_AMY + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
+                + TAG_DESC_TECH, new SubscribeCommand(expectedEntry));
+
+        // multiple descriptions - last description accepted
+        assertParseSuccess(parser, TITLE_DESC_BOB + DESCRIPTION_DESC_AMY + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
+                + TAG_DESC_TECH, new SubscribeCommand(expectedEntry));
+
+        // multiple links - last link accepted
+        assertParseSuccess(parser, TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_AMY + LINK_DESC_BOB
+                + TAG_DESC_TECH, new SubscribeCommand(expectedEntry));
+
+        // multiple tags - all accepted
+        Entry expectedEntryMultipleTags = new EntryBuilder(BOB).withTags(VALID_TAG_TECH, VALID_TAG_SCIENCE)
+                .build();
+        assertParseSuccess(parser, TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
+                + TAG_DESC_SCIENCE + TAG_DESC_TECH, new SubscribeCommand(expectedEntryMultipleTags));
+    }
+
+    @Test
+    public void parse_optionalFieldsMissing_success() {
+        // zero tags
+        Entry expectedEntry = new EntryBuilder(AMY).withTags().build();
+        assertParseSuccess(parser, TITLE_DESC_AMY + DESCRIPTION_DESC_AMY + LINK_DESC_AMY,
+                new SubscribeCommand(expectedEntry));
+    }
+
+    @Test
+    public void parse_compulsoryFieldMissing_failure() {
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, SubscribeCommand.MESSAGE_USAGE);
+
+        // missing link prefix
+        assertParseFailure(parser, TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + VALID_LINK_BOB,
+                expectedMessage);
+
+        // all prefixes missing
+        assertParseFailure(parser, VALID_TITLE_BOB + VALID_DESCRIPTION_BOB + VALID_LINK_BOB,
+                expectedMessage);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        // invalid title
+        assertParseFailure(parser, INVALID_TITLE_DESC + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
+                + TAG_DESC_SCIENCE + TAG_DESC_TECH, Title.formExceptionMessage(INVALID_TITLE.trim()));
+
+        // invalid description
+        assertParseFailure(parser, TITLE_DESC_BOB + INVALID_DESCRIPTION_DESC + LINK_DESC_BOB
+                + TAG_DESC_SCIENCE + TAG_DESC_TECH, Description.formExceptionMessage(INVALID_DESCRIPTION.trim()));
+
+        // invalid link
+        assertParseFailure(parser, TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + INVALID_LINK_DESC
+                + TAG_DESC_SCIENCE + TAG_DESC_TECH, Link.formExceptionMessage(INVALID_LINK.trim()));
+
+        // invalid tag
+        assertParseFailure(parser, TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
+                + INVALID_TAG_DESC, Tag.formExceptionMessage(INVALID_TAG.trim()));
+
+        // two invalid values, only first invalid value reported
+        assertParseFailure(parser, INVALID_TITLE_DESC + DESCRIPTION_DESC_BOB + LINK_DESC_BOB,
+                Title.formExceptionMessage(INVALID_TITLE.trim()));
+
+        // non-empty preamble
+        assertParseFailure(parser, PREAMBLE_NON_EMPTY + TITLE_DESC_BOB + DESCRIPTION_DESC_BOB + LINK_DESC_BOB
+                + TAG_DESC_SCIENCE + TAG_DESC_TECH,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, SubscribeCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/UnsubscribeCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnsubscribeCommandParserTest.java
@@ -1,0 +1,30 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.UnsubscribeCommand;
+
+/**
+ * Test scope: similar to {@code DeleteCommandParserTest}.
+ * @see DeleteCommandParserTest
+ */
+public class UnsubscribeCommandParserTest {
+
+    private UnsubscribeCommandParser parser = new UnsubscribeCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsUnsubscribeCommand() {
+        assertParseSuccess(parser, "1", new UnsubscribeCommand(INDEX_FIRST_ENTRY));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a",
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnsubscribeCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Increase coverage by adding tests for parsers.

### Summary of changes:
- Made `ParserUtil` abstract
- Tests added for:
  - `SubscribeCommandParser`
  - `UnsubscribeCommandParser`
  - `AddIndexCommandParser`
  - `BingWebSearchCommandParser`
  - `GoogleNewsCommandParser`
  - `DeleteArchiveEntryCommandParser`
  - `RefreshEntryCommandParser`
  - `RefreshFeedCommandParser`
- Tests updated for:
  - `ParserUtil#parseIndex`
  - `EntryBookArchivesParserTest`
  - `EntryBookFeedsParserTest`
  - `EntryBookListParserTest`
  - `EntryBookSearchParserTest`