### PR TITLE
Add tests and remove code to increase coverage

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -102,13 +102,6 @@ public interface Logic {
     ReadOnlyProperty<ViewMode> viewModeProperty();
 
     /**
-     * Sets the view mode.
-     *
-     * @see seedu.address.model.Model#setViewMode(ViewMode)
-     */
-    void setViewMode(ViewMode viewMode);
-
-    /**
      * Propagated exception.
      * null if no exception.
      *
@@ -145,12 +138,5 @@ public interface Logic {
      * @see seedu.address.model.Model#contextProperty()
      */
     ReadOnlyProperty<ModelContext> contextProperty();
-
-    /**
-     * Sets the context in the model.
-     *
-     * @see seedu.address.model.Model#setContext(ModelContext)
-     */
-    void setContext(ModelContext context);
 
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -142,11 +142,6 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public void setViewMode(ViewMode viewMode) {
-        model.setViewMode(viewMode);
-    }
-
-    @Override
     public ReadOnlyProperty<Exception> exceptionProperty() {
         return model.exceptionProperty();
     }
@@ -169,11 +164,6 @@ public class LogicManager implements Logic {
     @Override
     public ReadOnlyProperty<ModelContext> contextProperty() {
         return model.contextProperty();
-    }
-
-    @Override
-    public void setContext(ModelContext context) {
-        model.setContext(context);
     }
 
 }

--- a/src/main/java/seedu/address/ui/util/ReaderViewUtil.java
+++ b/src/main/java/seedu/address/ui/util/ReaderViewUtil.java
@@ -87,18 +87,6 @@ public class ReaderViewUtil {
     }
 
     /**
-     * Resolves relative links to absolute links.
-     * @param document Jsoup document parsed from raw HTML
-     */
-    public static void resolveRelativeLinksToAbsoluteLinks(Document document) {
-        document.select(ANCHOR_TAG)
-                .forEach(link -> {
-                    String absoluteUrl = link.absUrl("href");
-                    link.attr("href", absoluteUrl);
-                });
-    }
-
-    /**
      * Creates empty Jsoup document with given base URL
      * @param baseUrl base URL
      */
@@ -214,19 +202,6 @@ public class ReaderViewUtil {
                 .filter(title -> !title.isEmpty())
                 .map(title ->
                         new Element(Tag.valueOf(HEADER_TAG), "").text(title).addClass(TITLE_STYLE_CLASS)
-                );
-    }
-
-    /**
-     * Attempts to create an excerpt element.
-     * @param article Readability4J article
-     * @return optional excerpt element
-     */
-    private static Optional<Element> createExcerptElement(Article article) {
-        return Optional.ofNullable(article.getExcerpt())
-                .filter(excerpt -> !excerpt.isEmpty())
-                .map(excerpt ->
-                        new Element(Tag.valueOf(PARAGRAPH_TAG), "").text(excerpt).addClass(LEAD_STYLE_CLASS)
                 );
     }
 

--- a/src/test/java/seedu/address/commons/util/DateUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/DateUtilTest.java
@@ -1,0 +1,70 @@
+package seedu.address.commons.util;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.format.FormatStyle;
+
+import org.junit.Test;
+
+public class DateUtilTest {
+
+    @Test
+    public void getHumanReadableDateFrom() {
+        // valid dates
+        assertEquals(
+            "February 1, 2019",
+            DateUtil.getHumanReadableDateFrom("2019-02-01"));
+        assertEquals(
+            "February 1, 2019",
+            DateUtil.getHumanReadableDateFrom("2019-02-01T01:30"));
+        assertEquals(
+            "February 1, 2019",
+            DateUtil.getHumanReadableDateFrom("2019-02-01+01:30"));
+        assertEquals("February 1, 2019",
+            DateUtil.getHumanReadableDateFrom("2019-02-01T10:15:30Z"));
+
+        // valid dates with custom format
+        assertEquals(
+            "Feb 1, 2019",
+            DateUtil.getHumanReadableDateFrom("2019-02-01", FormatStyle.MEDIUM));
+
+        // invalid dates are untouched
+        assertEquals(
+            "invalid date",
+            DateUtil.getHumanReadableDateFrom("invalid date"));
+        assertEquals(
+            "invalid date",
+            DateUtil.getHumanReadableDateFrom("invalid date", FormatStyle.MEDIUM));
+    }
+
+    @Test
+    public void getHumanReadableDateTimeFrom() {
+        // valid dates
+        assertEquals(
+            "February 1, 2019",
+            DateUtil.getHumanReadableDateTimeFrom("2019-02-01"));
+        assertEquals(
+            "February 1, 2019, 1:30 AM",
+            DateUtil.getHumanReadableDateTimeFrom("2019-02-01T01:30"));
+        assertEquals(
+            "February 1, 2019",
+            DateUtil.getHumanReadableDateTimeFrom("2019-02-01+01:30"));
+        assertEquals(
+            "February 1, 2019, 10:15 AM",
+            DateUtil.getHumanReadableDateTimeFrom("2019-02-01T10:15:30Z"));
+
+        // valid dates with custom format
+        assertEquals(
+            "Feb 1, 2019, 10:15:30 AM",
+            DateUtil.getHumanReadableDateTimeFrom("2019-02-01T10:15:30Z", FormatStyle.MEDIUM, FormatStyle.MEDIUM));
+
+        // invalid dates are untouched
+        assertEquals(
+            "invalid date",
+            DateUtil.getHumanReadableDateTimeFrom("invalid date"));
+        assertEquals(
+            "invalid date",
+            DateUtil.getHumanReadableDateTimeFrom("invalid date", FormatStyle.MEDIUM, FormatStyle.MEDIUM));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -20,7 +20,9 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.ArchivesCommand;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.FeedsCommand;
 import seedu.address.logic.commands.HistoryCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -139,6 +141,46 @@ public class LogicManagerTest {
     public void getFilteredEntryList_modifyList_throwsUnsupportedOperationException() {
         thrown.expect(UnsupportedOperationException.class);
         logic.getFilteredEntryList().remove(0);
+    }
+
+    @Test
+    public void executeContextSwitch_success() {
+        logic.executeContextSwitch(ModelContext.CONTEXT_LIST);
+        assertEquals(ListCommand.MESSAGE_SUCCESS, model.getCommandResult().getFeedbackToUser());
+        assertEquals(model.getContext(), ModelContext.CONTEXT_LIST);
+
+        logic.executeContextSwitch(ModelContext.CONTEXT_ARCHIVES);
+        assertEquals(ArchivesCommand.MESSAGE_SUCCESS, model.getCommandResult().getFeedbackToUser());
+        assertEquals(model.getContext(), ModelContext.CONTEXT_ARCHIVES);
+
+        logic.executeContextSwitch(ModelContext.CONTEXT_FEEDS);
+        assertEquals(FeedsCommand.MESSAGE_SUCCESS, model.getCommandResult().getFeedbackToUser());
+        assertEquals(model.getContext(), ModelContext.CONTEXT_FEEDS);
+
+        // Test switching back to list context in case first one wasn't an accurate test
+        logic.executeContextSwitch(ModelContext.CONTEXT_LIST);
+        assertEquals(ListCommand.MESSAGE_SUCCESS, model.getCommandResult().getFeedbackToUser());
+        assertEquals(model.getContext(), ModelContext.CONTEXT_LIST);
+    }
+
+    /**
+     * Tests switching to search context,
+     * which does network calls (google news command),
+     * so we test this separately from above.
+     */
+    @Test
+    public void executeContextSwitchToSearchContext_success() {
+        logic.executeContextSwitch(ModelContext.CONTEXT_LIST);
+        assertEquals(ListCommand.MESSAGE_SUCCESS, model.getCommandResult().getFeedbackToUser());
+        assertEquals(model.getContext(), ModelContext.CONTEXT_LIST);
+
+        logic.executeContextSwitch(ModelContext.CONTEXT_SEARCH);
+        assertEquals(model.getContext(), ModelContext.CONTEXT_SEARCH);
+
+        // Test switching back to list context in case first one wasn't an accurate test
+        logic.executeContextSwitch(ModelContext.CONTEXT_LIST);
+        assertEquals(ListCommand.MESSAGE_SUCCESS, model.getCommandResult().getFeedbackToUser());
+        assertEquals(model.getContext(), ModelContext.CONTEXT_LIST);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/DeleteArchiveEntryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteArchiveEntryCommandTest.java
@@ -1,0 +1,123 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showEntryAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ENTRY;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_ENTRY;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.StorageStub;
+import seedu.address.mocks.TypicalModelManagerStub;
+import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.entry.Entry;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for
+ * {@code DeleteArchiveEntryCommand}.
+ */
+public class DeleteArchiveEntryCommandTest {
+
+    private Model model = new TypicalModelManagerStub();
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Before
+    public void setUp() {
+        model.setContext(ModelContext.CONTEXT_ARCHIVES);
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Entry entryToDelete = model.getFilteredEntryList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        DeleteArchiveEntryCommand deleteCommand = new DeleteArchiveEntryCommand(INDEX_FIRST_ENTRY);
+
+        String expectedMessage = String.format(DeleteArchiveEntryCommand.MESSAGE_DELETE_ENTRY_SUCCESS, entryToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getListEntryBook(), model.getArchivesEntryBook(),
+            model.getFeedsEntryBook(), new UserPrefs(), new StorageStub());
+        expectedModel.setContext(ModelContext.CONTEXT_ARCHIVES);
+        expectedModel.deleteArchivesEntry(entryToDelete);
+
+        assertCommandSuccess(deleteCommand, model, commandHistory, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredEntryList().size() + 1);
+        DeleteArchiveEntryCommand deleteCommand = new DeleteArchiveEntryCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, commandHistory, Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showEntryAtIndex(model, INDEX_FIRST_ENTRY);
+
+        Entry entryToDelete = model.getFilteredEntryList().get(INDEX_FIRST_ENTRY.getZeroBased());
+        DeleteArchiveEntryCommand deleteCommand = new DeleteArchiveEntryCommand(INDEX_FIRST_ENTRY);
+
+        String expectedMessage = String.format(DeleteArchiveEntryCommand.MESSAGE_DELETE_ENTRY_SUCCESS, entryToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getListEntryBook(), model.getArchivesEntryBook(),
+            model.getFeedsEntryBook(), new UserPrefs(), new StorageStub());
+        expectedModel.setContext(ModelContext.CONTEXT_ARCHIVES);
+        expectedModel.deleteArchivesEntry(entryToDelete);
+        showNoEntry(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, commandHistory, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showEntryAtIndex(model, INDEX_FIRST_ENTRY);
+
+        Index outOfBoundIndex = INDEX_SECOND_ENTRY;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getArchivesEntryBook().getEntryList().size());
+
+        DeleteArchiveEntryCommand deleteCommand = new DeleteArchiveEntryCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, commandHistory, Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        DeleteArchiveEntryCommand deleteFirstCommand = new DeleteArchiveEntryCommand(INDEX_FIRST_ENTRY);
+        DeleteArchiveEntryCommand deleteSecondCommand = new DeleteArchiveEntryCommand(INDEX_SECOND_ENTRY);
+
+        // same object -> returns true
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+
+        // same values -> returns true
+        DeleteArchiveEntryCommand deleteFirstCommandCopy = new DeleteArchiveEntryCommand(INDEX_FIRST_ENTRY);
+        assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(deleteFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(deleteFirstCommand.equals(null));
+
+        // different entry -> returns false
+        assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoEntry(Model model) {
+        model.updateFilteredEntryList(p -> false);
+
+        assertTrue(model.getFilteredEntryList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -188,18 +188,24 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void deleteEntry_entryIsSelectedAndFirstEntryInFilteredEntryList_selectionCleared() {
+    public void deleteListEntry_entryIsSelectedAndFirstEntryInFilteredEntryList_selectionCleared() {
         modelManager.addListEntry(ALICE, Optional.empty());
         modelManager.setSelectedEntry(ALICE);
         modelManager.deleteListEntry(ALICE);
         assertEquals(null, modelManager.getSelectedEntry());
+    }
 
+    @Test
+    public void deleteArchivesEntry_entryIsSelectedAndFirstEntryInFilteredEntryList_selectionCleared() {
         modelManager.setContext(ModelContext.CONTEXT_ARCHIVES);
         modelManager.addArchivesEntry(ALICE);
         modelManager.setSelectedEntry(ALICE);
         modelManager.deleteArchivesEntry(ALICE);
         assertEquals(null, modelManager.getSelectedEntry());
+    }
 
+    @Test
+    public void deleteFeedsEntry_entryIsSelectedAndFirstEntryInFilteredEntryList_selectionCleared() {
         modelManager.setContext(ModelContext.CONTEXT_FEEDS);
         modelManager.addFeedsEntry(ALICE);
         modelManager.setSelectedEntry(ALICE);

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -261,18 +261,24 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void setSelectedEntry_entryInFilteredEntryList_setsSelectedEntry() {
+    public void setSelectedEntryListContext_entryInFilteredEntryList_setsSelectedEntry() {
         modelManager.addListEntry(ALICE, Optional.empty());
         assertEquals(Collections.singletonList(ALICE), modelManager.getFilteredEntryList());
         modelManager.setSelectedEntry(ALICE);
         assertEquals(ALICE, modelManager.getSelectedEntry());
+    }
 
+    @Test
+    public void setSelectedEntryArchivesContext_entryInFilteredEntryList_setsSelectedEntry() {
         modelManager.setContext(ModelContext.CONTEXT_ARCHIVES);
         modelManager.addArchivesEntry(ALICE);
         assertEquals(Collections.singletonList(ALICE), modelManager.getFilteredEntryList());
         modelManager.setSelectedEntry(ALICE);
         assertEquals(ALICE, modelManager.getSelectedEntry());
+    }
 
+    @Test
+    public void setSelectedEntryFeedsContext_entryInFilteredEntryList_setsSelectedEntry() {
         modelManager.setContext(ModelContext.CONTEXT_FEEDS);
         modelManager.addFeedsEntry(ALICE);
         assertEquals(Collections.singletonList(ALICE), modelManager.getFilteredEntryList());

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -151,7 +151,7 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void hasListEntry_entryNotInEntryBook_returnsFalse() {
+    public void hasEntry_entryNotInEntryBook_returnsFalse() {
         assertFalse(modelManager.hasEntry(ALICE));
         assertFalse(modelManager.hasListEntry(ALICE));
         assertFalse(modelManager.hasArchivesEntry(ALICE));

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -133,21 +133,57 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void hasEntry_entryNotInEntryBook_returnsFalse() {
-        assertFalse(modelManager.hasEntry(ALICE));
+    public void hasListEntry_nullEntry_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        modelManager.hasListEntry(null);
     }
 
     @Test
-    public void hasEntry_entryInEntryBook_returnsTrue() {
+    public void hasArchivesEntry_nullEntry_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        modelManager.hasArchivesEntry(null);
+    }
+
+    @Test
+    public void hasFeedsEntry_nullEntry_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        modelManager.hasFeedsEntry(null);
+    }
+
+    @Test
+    public void hasListEntry_entryNotInEntryBook_returnsFalse() {
+        assertFalse(modelManager.hasEntry(ALICE));
+        assertFalse(modelManager.hasListEntry(ALICE));
+        assertFalse(modelManager.hasArchivesEntry(ALICE));
+        assertFalse(modelManager.hasFeedsEntry(ALICE));
+    }
+
+    @Test
+    public void hasListEntry_entryInEntryBook_returnsTrue() {
         modelManager.addListEntry(ALICE, Optional.empty());
         assertTrue(modelManager.hasEntry(ALICE));
+        assertTrue(modelManager.hasListEntry(ALICE));
+        assertFalse(modelManager.hasArchivesEntry(ALICE));
+        assertFalse(modelManager.hasFeedsEntry(ALICE));
+    }
 
+    @Test
+    public void hasArchivesEntry_entryInEntryBook_returnsTrue() {
         modelManager.setContext(ModelContext.CONTEXT_ARCHIVES);
         modelManager.addArchivesEntry(ALICE);
+        assertTrue(modelManager.hasEntry(ALICE));
+        assertFalse(modelManager.hasListEntry(ALICE));
         assertTrue(modelManager.hasArchivesEntry(ALICE));
+        assertFalse(modelManager.hasFeedsEntry(ALICE));
+    }
 
+    @Test
+    public void hasFeedsEntry_entryInEntryBook_returnsTrue() {
         modelManager.setContext(ModelContext.CONTEXT_FEEDS);
         modelManager.addFeedsEntry(ALICE);
+        assertFalse(modelManager.hasEntry(ALICE));
+        assertFalse(modelManager.hasListEntry(ALICE));
+        assertFalse(modelManager.hasArchivesEntry(ALICE));
         assertTrue(modelManager.hasFeedsEntry(ALICE));
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -208,14 +208,17 @@ public class ModelManagerTest {
     }
 
     @Test
-    public void deleteEntry_entryIsSelectedAndSecondEntryInFilteredEntryList_firstEntrySelected() {
+    public void deleteListEntry_entryIsSelectedAndSecondEntryInFilteredEntryList_firstEntrySelected() {
         modelManager.addListEntry(ALICE, Optional.empty());
         modelManager.addListEntry(BOB, Optional.empty());
         assertEquals(Arrays.asList(ALICE, BOB), modelManager.getFilteredEntryList());
         modelManager.setSelectedEntry(BOB);
         modelManager.deleteListEntry(BOB);
         assertEquals(ALICE, modelManager.getSelectedEntry());
+    }
 
+    @Test
+    public void deleteArchivesEntry_entryIsSelectedAndSecondEntryInFilteredEntryList_firstEntrySelected() {
         modelManager.setContext(ModelContext.CONTEXT_ARCHIVES);
         modelManager.addArchivesEntry(ALICE);
         modelManager.addArchivesEntry(BOB);
@@ -223,7 +226,10 @@ public class ModelManagerTest {
         modelManager.setSelectedEntry(BOB);
         modelManager.deleteArchivesEntry(BOB);
         assertEquals(ALICE, modelManager.getSelectedEntry());
+    }
 
+    @Test
+    public void deleteFeedsEntry_entryIsSelectedAndSecondEntryInFilteredEntryList_firstEntrySelected() {
         modelManager.setContext(ModelContext.CONTEXT_FEEDS);
         modelManager.addFeedsEntry(ALICE);
         modelManager.addFeedsEntry(BOB);

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -114,6 +114,19 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void setArchivesEntryBookFilePath_nullPath_throwsNullPointerException() {
+        thrown.expect(NullPointerException.class);
+        modelManager.setArchivesEntryBookFilePath(null);
+    }
+
+    @Test
+    public void setArchivesEntryBookFilePath_validPath_setsEntryBookFilePath() {
+        Path path = Paths.get("archive/book/file/path");
+        modelManager.setArchivesEntryBookFilePath(path);
+        assertEquals(path, modelManager.getArchivesEntryBookFilePath());
+    }
+
+    @Test
     public void hasEntry_nullEntry_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
         modelManager.hasEntry(null);
@@ -128,6 +141,14 @@ public class ModelManagerTest {
     public void hasEntry_entryInEntryBook_returnsTrue() {
         modelManager.addListEntry(ALICE, Optional.empty());
         assertTrue(modelManager.hasEntry(ALICE));
+
+        modelManager.setContext(ModelContext.CONTEXT_ARCHIVES);
+        modelManager.addArchivesEntry(ALICE);
+        assertTrue(modelManager.hasArchivesEntry(ALICE));
+
+        modelManager.setContext(ModelContext.CONTEXT_FEEDS);
+        modelManager.addFeedsEntry(ALICE);
+        assertTrue(modelManager.hasFeedsEntry(ALICE));
     }
 
     @Test
@@ -135,6 +156,18 @@ public class ModelManagerTest {
         modelManager.addListEntry(ALICE, Optional.empty());
         modelManager.setSelectedEntry(ALICE);
         modelManager.deleteListEntry(ALICE);
+        assertEquals(null, modelManager.getSelectedEntry());
+
+        modelManager.setContext(ModelContext.CONTEXT_ARCHIVES);
+        modelManager.addArchivesEntry(ALICE);
+        modelManager.setSelectedEntry(ALICE);
+        modelManager.deleteArchivesEntry(ALICE);
+        assertEquals(null, modelManager.getSelectedEntry());
+
+        modelManager.setContext(ModelContext.CONTEXT_FEEDS);
+        modelManager.addFeedsEntry(ALICE);
+        modelManager.setSelectedEntry(ALICE);
+        modelManager.deleteFeedsEntry(ALICE);
         assertEquals(null, modelManager.getSelectedEntry());
     }
 
@@ -145,6 +178,22 @@ public class ModelManagerTest {
         assertEquals(Arrays.asList(ALICE, BOB), modelManager.getFilteredEntryList());
         modelManager.setSelectedEntry(BOB);
         modelManager.deleteListEntry(BOB);
+        assertEquals(ALICE, modelManager.getSelectedEntry());
+
+        modelManager.setContext(ModelContext.CONTEXT_ARCHIVES);
+        modelManager.addArchivesEntry(ALICE);
+        modelManager.addArchivesEntry(BOB);
+        assertEquals(Arrays.asList(ALICE, BOB), modelManager.getFilteredEntryList());
+        modelManager.setSelectedEntry(BOB);
+        modelManager.deleteArchivesEntry(BOB);
+        assertEquals(ALICE, modelManager.getSelectedEntry());
+
+        modelManager.setContext(ModelContext.CONTEXT_FEEDS);
+        modelManager.addFeedsEntry(ALICE);
+        modelManager.addFeedsEntry(BOB);
+        assertEquals(Arrays.asList(ALICE, BOB), modelManager.getFilteredEntryList());
+        modelManager.setSelectedEntry(BOB);
+        modelManager.deleteFeedsEntry(BOB);
         assertEquals(ALICE, modelManager.getSelectedEntry());
     }
 
@@ -172,6 +221,18 @@ public class ModelManagerTest {
     @Test
     public void setSelectedEntry_entryInFilteredEntryList_setsSelectedEntry() {
         modelManager.addListEntry(ALICE, Optional.empty());
+        assertEquals(Collections.singletonList(ALICE), modelManager.getFilteredEntryList());
+        modelManager.setSelectedEntry(ALICE);
+        assertEquals(ALICE, modelManager.getSelectedEntry());
+
+        modelManager.setContext(ModelContext.CONTEXT_ARCHIVES);
+        modelManager.addArchivesEntry(ALICE);
+        assertEquals(Collections.singletonList(ALICE), modelManager.getFilteredEntryList());
+        modelManager.setSelectedEntry(ALICE);
+        assertEquals(ALICE, modelManager.getSelectedEntry());
+
+        modelManager.setContext(ModelContext.CONTEXT_FEEDS);
+        modelManager.addFeedsEntry(ALICE);
         assertEquals(Collections.singletonList(ALICE), modelManager.getFilteredEntryList());
         modelManager.setSelectedEntry(ALICE);
         assertEquals(ALICE, modelManager.getSelectedEntry());


### PR DESCRIPTION
Some tests over the place to increase coverage.
Also removed unused code to increase coverage.

### Summary of changes:
- Removed unused code:
  - `Logic#setViewMode`
  - `Logic#setContext`
  - `ReaderViewUtil#resolveRelativeLinksToAbsoluteLinks`
  - `ReaderViewUtil#createExcerptElement`
- Add tests for:
  - `DateUtil`
  - `Logic#executeContextSwitch`, which covers some other methods as well
  - `DeleteArchiveEntryCommand`
  - `Model#setArchivesEntryBookFilePath`
  - `Model#hasArchivesEntry`, `Model#hasFeedsEntry`
  - `Model#deleteArchivesEntry`, `Model#deleteFeedsEntry` (and its interaction with selected entry)