### PR TITLE
Promote clear command to archives and feeds context

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearArchivesCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearArchivesCommand.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+
+/**
+ * Clears the archives list
+ */
+public class ClearArchivesCommand extends Command {
+
+    public static final String COMMAND_WORD = "clear";
+    public static final String MESSAGE_SUCCESS = "Archives list has been cleared!";
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) {
+        requireNonNull(model);
+        model.clearArchivesEntryBook();
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ClearFeedsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearFeedsCommand.java
@@ -1,0 +1,22 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.model.Model;
+
+/**
+ * Clears the feeds list
+ */
+public class ClearFeedsCommand extends Command {
+
+    public static final String COMMAND_WORD = "clear";
+    public static final String MESSAGE_SUCCESS = "Feeds list has been cleared!";
+
+    @Override
+    public CommandResult execute(Model model, CommandHistory history) {
+        requireNonNull(model);
+        model.clearFeedsEntryBook();
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ClearListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearListCommand.java
@@ -6,12 +6,12 @@ import seedu.address.logic.CommandHistory;
 import seedu.address.model.Model;
 
 /**
- * Clears the address book.
+ * Clears the reading list.
  */
-public class ClearCommand extends Command {
+public class ClearListCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Entry book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "Reading list has been cleared!";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/EntryBookArchivesParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookArchivesParser.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import java.util.regex.Matcher;
 
+import seedu.address.logic.commands.ClearArchivesCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteArchiveEntryCommand;
 import seedu.address.logic.commands.FindCommand;
@@ -48,6 +49,9 @@ public class EntryBookArchivesParser extends EntryBookParser {
         case SelectCommand.COMMAND_WORD:
         case SelectCommand.COMMAND_ALIAS:
             return new SelectCommandParser().parse(arguments);
+
+        case ClearArchivesCommand.COMMAND_WORD:
+            return new ClearArchivesCommand();
 
         case UnarchiveCommand.COMMAND_WORD:
         case UnarchiveCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/logic/parser/EntryBookFeedsParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookFeedsParser.java
@@ -4,6 +4,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 
 import java.util.regex.Matcher;
 
+import seedu.address.logic.commands.ClearFeedsCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.RefreshFeedCommand;
@@ -36,6 +37,9 @@ public class EntryBookFeedsParser extends EntryBookParser {
         case SelectCommand.COMMAND_WORD:
         case SelectCommand.COMMAND_ALIAS:
             return new SelectCommandParser().parse(arguments);
+
+        case ClearFeedsCommand.COMMAND_WORD:
+            return new ClearFeedsCommand();
 
         case UnsubscribeCommand.COMMAND_WORD:
         case UnsubscribeCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
+++ b/src/main/java/seedu/address/logic/parser/EntryBookListParser.java
@@ -5,7 +5,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT
 import java.util.regex.Matcher;
 
 import seedu.address.logic.commands.ArchiveCommand;
-import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearListCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
@@ -53,8 +53,8 @@ public class EntryBookListParser extends EntryBookParser {
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+        case ClearListCommand.COMMAND_WORD:
+            return new ClearListCommand();
 
         case FindCommand.COMMAND_WORD:
         case FindCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -156,6 +156,11 @@ public interface Model {
      */
     void clearArchivesEntryBook();
 
+    /**
+     * Replaces feeds entry book data with the data in {@code feedsEntryBook}.
+     */
+    void setFeedsEntryBook(ReadOnlyEntryBook feedsEntryBook);
+
     /** Returns the feeds entry book. */
     ReadOnlyEntryBook getFeedsEntryBook();
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -288,6 +288,11 @@ public class ModelManager implements Model {
     //=========== Feeds EntryBook ============================================================================
 
     @Override
+    public void setFeedsEntryBook(ReadOnlyEntryBook feedsEntryBook) {
+        this.feedsEntryBook.resetData(feedsEntryBook);
+    }
+
+    @Override
     public ReadOnlyEntryBook getFeedsEntryBook() {
         return feedsEntryBook;
     }

--- a/src/test/java/seedu/address/TestApp.java
+++ b/src/test/java/seedu/address/TestApp.java
@@ -35,13 +35,18 @@ public class TestApp extends MainApp {
     public static final Path SAVE_LOCATION_ARCHIVES_ENTRYBOOK_FOR_TESTING =
         TestUtil.getFilePathInSandboxFolder("sampleArchiveEntryBookData.json");
 
+    public static final Path SAVE_LOCATION_FEEDS_ENTRYBOOK_FOR_TESTING =
+        TestUtil.getFilePathInSandboxFolder("sampleFeedsEntryBookData.json");
+
     protected static final Path DEFAULT_PREF_FILE_LOCATION_FOR_TESTING =
             TestUtil.getFilePathInSandboxFolder("pref_testing.json");
 
     protected Supplier<ReadOnlyEntryBook> initialListEntryBookDataSupplier = () -> null;
     protected Supplier<ReadOnlyEntryBook> initialArchivesEntryBookDataSupplier = () -> null;
+    protected Supplier<ReadOnlyEntryBook> initialFeedsEntryBookDataSupplier = () -> null;
     protected Path saveFileLocationListEntryBook = SAVE_LOCATION_LIST_ENTRYBOOK_FOR_TESTING;
     protected Path saveFileLocationArchivesEntryBook = SAVE_LOCATION_ARCHIVES_ENTRYBOOK_FOR_TESTING;
+    protected Path saveFileLocationFeedsEntryBook = SAVE_LOCATION_FEEDS_ENTRYBOOK_FOR_TESTING;
 
     public TestApp() {
     }
@@ -49,13 +54,17 @@ public class TestApp extends MainApp {
     public TestApp(
         Supplier<ReadOnlyEntryBook> initialListEntryBookDataSupplier,
         Supplier<ReadOnlyEntryBook> initialArchivesEntryBookDataSupplier,
+        Supplier<ReadOnlyEntryBook> initialFeedsEntryBookDataSupplier,
         Path saveFileLocationListEntryBook,
-        Path saveFileLocationArchivesEntryBook) {
+        Path saveFileLocationArchivesEntryBook,
+        Path saveFileLocationFeedsEntryBook) {
         super();
         this.initialListEntryBookDataSupplier = initialListEntryBookDataSupplier;
         this.initialArchivesEntryBookDataSupplier = initialArchivesEntryBookDataSupplier;
+        this.initialFeedsEntryBookDataSupplier = initialFeedsEntryBookDataSupplier;
         this.saveFileLocationListEntryBook = saveFileLocationListEntryBook;
         this.saveFileLocationArchivesEntryBook = saveFileLocationArchivesEntryBook;
+        this.saveFileLocationFeedsEntryBook = saveFileLocationFeedsEntryBook;
 
         // If some initial local data has been provided, write those to the file
         if (initialListEntryBookDataSupplier.get() != null) {
@@ -70,6 +79,14 @@ public class TestApp extends MainApp {
             JsonEntryBookStorage jsonEntryBookStorage = new JsonEntryBookStorage(saveFileLocationArchivesEntryBook);
             try {
                 jsonEntryBookStorage.saveEntryBook(initialArchivesEntryBookDataSupplier.get());
+            } catch (IOException ioe) {
+                throw new AssertionError(ioe);
+            }
+        }
+        if (initialFeedsEntryBookDataSupplier.get() != null) {
+            JsonEntryBookStorage jsonEntryBookStorage = new JsonEntryBookStorage(saveFileLocationFeedsEntryBook);
+            try {
+                jsonEntryBookStorage.saveEntryBook(initialFeedsEntryBookDataSupplier.get());
             } catch (IOException ioe) {
                 throw new AssertionError(ioe);
             }
@@ -91,6 +108,7 @@ public class TestApp extends MainApp {
         userPrefs.setGuiSettings(new GuiSettings(600.0, 600.0, (int) x, (int) y));
         userPrefs.setListEntryBookFilePath(saveFileLocationListEntryBook);
         userPrefs.setArchivesEntryBookFilePath(saveFileLocationArchivesEntryBook);
+        userPrefs.setFeedsEntryBookFilePath(saveFileLocationFeedsEntryBook);
         return userPrefs;
     }
 
@@ -121,6 +139,19 @@ public class TestApp extends MainApp {
     }
 
     /**
+     * Returns a defensive copy of the feeds entry book data stored inside the storage file.
+     */
+    public EntryBook readStorageFeedsEntryBook() {
+        try {
+            return new EntryBook(storage.readFeedsEntryBook().get());
+        } catch (DataConversionException dce) {
+            throw new AssertionError("Data is not in the EntryBook format.", dce);
+        } catch (IOException ioe) {
+            throw new AssertionError("Storage file cannot be found.", ioe);
+        }
+    }
+
+    /**
      * Returns the file path of the storage file for the list entry book.
      */
     public Path getListEntryBookStorageSaveLocation() {
@@ -132,6 +163,13 @@ public class TestApp extends MainApp {
      */
     public Path getArchivesEntryBookStorageSaveLocation() {
         return storage.getArchivesEntryBookFilePath();
+    }
+
+    /**
+     * Returns the file path of the storage file for the feeds entry book.
+     */
+    public Path getFeedsEntryBookStorageSaveLocation() {
+        return storage.getFeedsEntryBookFilePath();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -331,6 +331,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public void setFeedsEntryBook(ReadOnlyEntryBook feedsEntryBook) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public ReadOnlyEntryBook getFeedsEntryBook() {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/address/logic/commands/ClearArchivesCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearArchivesCommandTest.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import org.junit.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.ModelManagerStub;
+import seedu.address.mocks.TypicalModelManagerStub;
+import seedu.address.model.EntryBook;
+import seedu.address.model.Model;
+
+public class ClearArchivesCommandTest {
+
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_emptyEntryBook_success() {
+        Model model = new ModelManagerStub();
+        Model expectedModel = new ModelManagerStub();
+
+        assertCommandSuccess(
+            new ClearArchivesCommand(),
+            model,
+            commandHistory,
+            ClearArchivesCommand.MESSAGE_SUCCESS,
+            expectedModel);
+    }
+
+    @Test
+    public void execute_nonEmptyEntryBook_success() {
+        Model model = new TypicalModelManagerStub();
+        Model expectedModel = new TypicalModelManagerStub();
+        expectedModel.setArchivesEntryBook(new EntryBook());
+
+        assertCommandSuccess(
+            new ClearArchivesCommand(),
+            model,
+            commandHistory,
+            ClearArchivesCommand.MESSAGE_SUCCESS,
+            expectedModel);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/ClearFeedsCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearFeedsCommandTest.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import org.junit.Test;
+
+import seedu.address.logic.CommandHistory;
+import seedu.address.mocks.ModelManagerStub;
+import seedu.address.mocks.TypicalModelManagerStub;
+import seedu.address.model.EntryBook;
+import seedu.address.model.Model;
+
+public class ClearFeedsCommandTest {
+
+    private CommandHistory commandHistory = new CommandHistory();
+
+    @Test
+    public void execute_emptyEntryBook_success() {
+        Model model = new ModelManagerStub();
+        Model expectedModel = new ModelManagerStub();
+
+        assertCommandSuccess(
+            new ClearFeedsCommand(),
+            model,
+            commandHistory,
+            ClearFeedsCommand.MESSAGE_SUCCESS,
+            expectedModel);
+    }
+
+    @Test
+    public void execute_nonEmptyEntryBook_success() {
+        Model model = new TypicalModelManagerStub();
+        Model expectedModel = new TypicalModelManagerStub();
+        expectedModel.setFeedsEntryBook(new EntryBook());
+
+        assertCommandSuccess(
+            new ClearFeedsCommand(),
+            model,
+            commandHistory,
+            ClearFeedsCommand.MESSAGE_SUCCESS,
+            expectedModel);
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/ClearListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ClearListCommandTest.java
@@ -10,7 +10,7 @@ import seedu.address.mocks.TypicalModelManagerStub;
 import seedu.address.model.EntryBook;
 import seedu.address.model.Model;
 
-public class ClearCommandTest {
+public class ClearListCommandTest {
 
     private CommandHistory commandHistory = new CommandHistory();
 
@@ -19,7 +19,12 @@ public class ClearCommandTest {
         Model model = new ModelManagerStub();
         Model expectedModel = new ModelManagerStub();
 
-        assertCommandSuccess(new ClearCommand(), model, commandHistory, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(
+            new ClearListCommand(),
+            model,
+            commandHistory,
+            ClearListCommand.MESSAGE_SUCCESS,
+            expectedModel);
     }
 
     @Test
@@ -28,7 +33,12 @@ public class ClearCommandTest {
         Model expectedModel = new TypicalModelManagerStub();
         expectedModel.setListEntryBook(new EntryBook());
 
-        assertCommandSuccess(new ClearCommand(), model, commandHistory, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(
+            new ClearListCommand(),
+            model,
+            commandHistory,
+            ClearListCommand.MESSAGE_SUCCESS,
+            expectedModel);
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -142,7 +142,7 @@ public class EditCommandTest {
         assertFalse(standardCommand.equals(null));
 
         // different types -> returns false
-        assertFalse(standardCommand.equals(new ClearCommand()));
+        assertFalse(standardCommand.equals(new ClearListCommand()));
 
         // different index -> returns false
         assertFalse(standardCommand.equals(new EditCommand(INDEX_SECOND_ENTRY, DESC_AMY)));

--- a/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EntryBookListParserTest.java
@@ -17,7 +17,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ArchiveCommand;
 import seedu.address.logic.commands.ArchivesCommand;
 import seedu.address.logic.commands.BingWebSearchCommand;
-import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearListCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditEntryDescriptor;
@@ -76,8 +76,8 @@ public class EntryBookListParserTest {
 
     @Test
     public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearListCommand.COMMAND_WORD) instanceof ClearListCommand);
+        assertTrue(parser.parseCommand(ClearListCommand.COMMAND_WORD + " 3") instanceof ClearListCommand);
     }
 
     @Test

--- a/src/test/java/systemtests/ClearArchivesCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearArchivesCommandSystemTest.java
@@ -1,0 +1,86 @@
+package systemtests;
+
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.ArchivesCommand;
+import seedu.address.logic.commands.ClearArchivesCommand;
+import seedu.address.mocks.ModelManagerStub;
+import seedu.address.model.Model;
+import seedu.address.model.ModelContext;
+
+public class ClearArchivesCommandSystemTest extends EntryBookSystemTest {
+
+    @Test
+    public void clear() {
+        final Model defaultModel = getModel();
+
+        // Switch to archives context
+        executeCommand(ArchivesCommand.COMMAND_WORD);
+
+        /* Case: clear non-empty archives entry book,
+         * command with leading spaces and trailing alphanumeric characters and
+         * spaces -> cleared
+         */
+        assertCommandSuccess("   " + ClearArchivesCommand.COMMAND_WORD + " ab12   ");
+        assertSelectedCardUnchanged();
+
+        /* Case: clear empty address book -> cleared */
+        assertCommandSuccess(ClearArchivesCommand.COMMAND_WORD);
+        assertSelectedCardUnchanged();
+
+        /* Case: mixed case command word -> rejected */
+        assertCommandFailure("ClEaR", String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_ARCHIVES));
+    }
+
+    /**
+     * Executes {@code command} and verifies that the command box displays an empty string, the result display
+     * box displays {@code ClearArchivesCommand#MESSAGE_SUCCESS}
+     * and the model related components equal to an empty model.
+     * These verifications are done by
+     * {@code EntryBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
+     * Also verifies that the command box has the default style class and the status bar's sync status changes.
+     * @see EntryBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     */
+    private void assertCommandSuccess(String command) {
+        Model expectedModel = new ModelManagerStub();
+        expectedModel.setContext(ModelContext.CONTEXT_ARCHIVES);
+        expectedModel.setListEntryBook(getModel().getListEntryBook());
+        assertCommandSuccess(command, ClearArchivesCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    /**
+     * Performs the same verification as {@code assertCommandSuccess(String)} except that the result box displays
+     * {@code expectedResultMessage} and the model related components equal to {@code expectedModel}.
+     * @see ClearArchivesCommandSystemTest#assertCommandSuccess(String)
+     */
+    private void assertCommandSuccess(String command, String expectedResultMessage, Model expectedModel) {
+        executeCommand(command);
+        assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
+        assertCommandBoxShowsDefaultStyle();
+        assertResultDisplayShowsDefaultStyle();
+        assertStatusBarExcludingCountUnchanged();
+    }
+
+    /**
+     * Executes {@code command} and verifies that the command box displays {@code command}, the result display
+     * box displays {@code expectedResultMessage} and the model related components equal to the current model.
+     * These verifications are done by
+     * {@code EntryBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
+     * Also verifies that the browser url, selected card and status bar excluding count remain unchanged,
+     * and the command box has the error style.
+     * @see EntryBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     */
+    private void assertCommandFailure(String command, String expectedResultMessage) {
+        Model expectedModel = getModel();
+        expectedModel.setContext(ModelContext.CONTEXT_ARCHIVES);
+
+        executeCommand(command);
+        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);
+        assertSelectedCardUnchanged();
+        assertCommandBoxShowsErrorStyle();
+        assertResultDisplayShowsErrorStyle();
+        assertStatusBarExcludingCountUnchanged();
+    }
+}

--- a/src/test/java/systemtests/ClearFeedsCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearFeedsCommandSystemTest.java
@@ -4,39 +4,38 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import org.junit.Test;
 
-import seedu.address.logic.commands.ArchivesCommand;
-import seedu.address.logic.commands.ClearArchivesCommand;
+import seedu.address.logic.commands.ClearFeedsCommand;
+import seedu.address.logic.commands.FeedsCommand;
 import seedu.address.mocks.ModelManagerStub;
 import seedu.address.model.Model;
 import seedu.address.model.ModelContext;
 
-public class ClearArchivesCommandSystemTest extends EntryBookSystemTest {
+public class ClearFeedsCommandSystemTest extends EntryBookSystemTest {
 
     @Test
     public void clear() {
         final Model defaultModel = getModel();
 
-        // Switch to archives context
-        executeCommand(ArchivesCommand.COMMAND_WORD);
+        // Switch to feeds context
+        executeCommand(FeedsCommand.COMMAND_WORD);
 
-        /* Case: clear non-empty archives entry book,
-         * command with leading spaces and trailing alphanumeric characters and
+        /* Case: clear non-empty feeds entry book, command with leading spaces and trailing alphanumeric characters and
          * spaces -> cleared
          */
-        assertCommandSuccess("   " + ClearArchivesCommand.COMMAND_WORD + " ab12   ");
+        assertCommandSuccess("   " + ClearFeedsCommand.COMMAND_WORD + " ab12   ");
         assertSelectedCardUnchanged();
 
-        /* Case: clear empty address book -> cleared */
-        assertCommandSuccess(ClearArchivesCommand.COMMAND_WORD);
+        /* Case: clear empty feeds entry book -> cleared */
+        assertCommandSuccess(ClearFeedsCommand.COMMAND_WORD);
         assertSelectedCardUnchanged();
 
         /* Case: mixed case command word -> rejected */
-        assertCommandFailure("ClEaR", String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_ARCHIVES));
+        assertCommandFailure("ClEaR", String.format(MESSAGE_UNKNOWN_COMMAND, ModelContext.CONTEXT_FEEDS));
     }
 
     /**
      * Executes {@code command} and verifies that the command box displays an empty string, the result display
-     * box displays {@code ClearArchivesCommand#MESSAGE_SUCCESS}
+     * box displays {@code ClearFeedsCommand#MESSAGE_SUCCESS}
      * and the model related components equal to an empty model.
      * These verifications are done by
      * {@code EntryBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
@@ -45,16 +44,16 @@ public class ClearArchivesCommandSystemTest extends EntryBookSystemTest {
      */
     private void assertCommandSuccess(String command) {
         Model expectedModel = new ModelManagerStub();
-        expectedModel.setContext(ModelContext.CONTEXT_ARCHIVES);
+        expectedModel.setContext(ModelContext.CONTEXT_FEEDS);
         expectedModel.setListEntryBook(getModel().getListEntryBook());
-        expectedModel.setFeedsEntryBook(getModel().getFeedsEntryBook());
-        assertCommandSuccess(command, ClearArchivesCommand.MESSAGE_SUCCESS, expectedModel);
+        expectedModel.setArchivesEntryBook(getModel().getArchivesEntryBook());
+        assertCommandSuccess(command, ClearFeedsCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     /**
      * Performs the same verification as {@code assertCommandSuccess(String)} except that the result box displays
      * {@code expectedResultMessage} and the model related components equal to {@code expectedModel}.
-     * @see ClearArchivesCommandSystemTest#assertCommandSuccess(String)
+     * @see ClearFeedsCommandSystemTest#assertCommandSuccess(String)
      */
     private void assertCommandSuccess(String command, String expectedResultMessage, Model expectedModel) {
         executeCommand(command);
@@ -75,7 +74,7 @@ public class ClearArchivesCommandSystemTest extends EntryBookSystemTest {
      */
     private void assertCommandFailure(String command, String expectedResultMessage) {
         Model expectedModel = getModel();
-        expectedModel.setContext(ModelContext.CONTEXT_ARCHIVES);
+        expectedModel.setContext(ModelContext.CONTEXT_FEEDS);
 
         executeCommand(command);
         assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);

--- a/src/test/java/systemtests/ClearListCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearListCommandSystemTest.java
@@ -15,7 +15,7 @@ public class ClearListCommandSystemTest extends EntryBookSystemTest {
     public void clear() {
         final Model defaultModel = getModel();
 
-        /* Case: clear non-empty address book, command with leading spaces and trailing alphanumeric characters and
+        /* Case: clear non-empty list entry book, command with leading spaces and trailing alphanumeric characters and
          * spaces -> cleared
          */
         assertCommandSuccess("   " + ClearListCommand.COMMAND_WORD + " ab12   ");
@@ -40,6 +40,7 @@ public class ClearListCommandSystemTest extends EntryBookSystemTest {
     private void assertCommandSuccess(String command) {
         Model expectedModel = new ModelManagerStub();
         expectedModel.setArchivesEntryBook(getModel().getArchivesEntryBook());
+        expectedModel.setFeedsEntryBook(getModel().getFeedsEntryBook());
         assertCommandSuccess(command, ClearListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 

--- a/src/test/java/systemtests/ClearListCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearListCommandSystemTest.java
@@ -4,12 +4,12 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
 import org.junit.Test;
 
-import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearListCommand;
 import seedu.address.mocks.ModelManagerStub;
 import seedu.address.model.Model;
 import seedu.address.model.ModelContext;
 
-public class ClearCommandSystemTest extends EntryBookSystemTest {
+public class ClearListCommandSystemTest extends EntryBookSystemTest {
 
     @Test
     public void clear() {
@@ -18,11 +18,11 @@ public class ClearCommandSystemTest extends EntryBookSystemTest {
         /* Case: clear non-empty address book, command with leading spaces and trailing alphanumeric characters and
          * spaces -> cleared
          */
-        assertCommandSuccess("   " + ClearCommand.COMMAND_WORD + " ab12   ");
+        assertCommandSuccess("   " + ClearListCommand.COMMAND_WORD + " ab12   ");
         assertSelectedCardUnchanged();
 
         /* Case: clear empty address book -> cleared */
-        assertCommandSuccess(ClearCommand.COMMAND_WORD);
+        assertCommandSuccess(ClearListCommand.COMMAND_WORD);
         assertSelectedCardUnchanged();
 
         /* Case: mixed case command word -> rejected */
@@ -31,7 +31,7 @@ public class ClearCommandSystemTest extends EntryBookSystemTest {
 
     /**
      * Executes {@code command} and verifies that the command box displays an empty string, the result display
-     * box displays {@code ClearCommand#MESSAGE_SUCCESS} and the model related components equal to an empty model.
+     * box displays {@code ClearListCommand#MESSAGE_SUCCESS} and the model related components equal to an empty model.
      * These verifications are done by
      * {@code EntryBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
      * Also verifies that the command box has the default style class and the status bar's sync status changes.
@@ -40,13 +40,13 @@ public class ClearCommandSystemTest extends EntryBookSystemTest {
     private void assertCommandSuccess(String command) {
         Model expectedModel = new ModelManagerStub();
         expectedModel.setArchivesEntryBook(getModel().getArchivesEntryBook());
-        assertCommandSuccess(command, ClearCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(command, ClearListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     /**
      * Performs the same verification as {@code assertCommandSuccess(String)} except that the result box displays
      * {@code expectedResultMessage} and the model related components equal to {@code expectedModel}.
-     * @see ClearCommandSystemTest#assertCommandSuccess(String)
+     * @see ClearListCommandSystemTest#assertCommandSuccess(String)
      */
     private void assertCommandSuccess(String command, String expectedResultMessage, Model expectedModel) {
         executeCommand(command);

--- a/src/test/java/systemtests/EntryBookSystemTest.java
+++ b/src/test/java/systemtests/EntryBookSystemTest.java
@@ -33,7 +33,7 @@ import guitests.guihandles.StatusBarFooterHandle;
 import seedu.address.TestApp;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ArchivesCommand;
-import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.ClearListCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -207,7 +207,7 @@ public abstract class EntryBookSystemTest {
      * Deletes all entries in the address book.
      */
     protected void deleteAllEntries() {
-        executeCommand(ClearCommand.COMMAND_WORD);
+        executeCommand(ClearListCommand.COMMAND_WORD);
         assertEquals(0, getModel().getListEntryBook().getEntryList().size());
     }
 

--- a/src/test/java/systemtests/EntryBookSystemTest.java
+++ b/src/test/java/systemtests/EntryBookSystemTest.java
@@ -78,8 +78,10 @@ public abstract class EntryBookSystemTest {
         testApp = setupHelper.setupApplication(
                                 this::getInitialDataListEntryBook,
                                 this::getInitialDataArchivesEntryBook,
+                                this::getInitialDataFeedsEntryBook,
                                 getDataFileLocationListEntryBook(),
-                                getDataFileLocationArchivesEntryBook());
+                                getDataFileLocationArchivesEntryBook(),
+                                getDataFileLocationFeedsEntryBook());
         mainWindowHandle = setupHelper.setupMainWindowHandle();
 
         waitUntilBrowserLoaded(getBrowserPanel());
@@ -101,10 +103,18 @@ public abstract class EntryBookSystemTest {
 
     /**
      * Returns the data for the archives entry book to be loaded into the file in
-     * {@link #getDataFileLocationListEntryBook()}.
+     * {@link #getDataFileLocationArchivesEntryBook()}.
      */
     protected EntryBook getInitialDataArchivesEntryBook() {
         return TypicalEntries.getTypicalArchivesEntryBook();
+    }
+
+    /**
+     * Returns the data for the feeds entry book to be loaded into the file in
+     * {@link #getDataFileLocationFeedsEntryBook()}.
+     */
+    protected EntryBook getInitialDataFeedsEntryBook() {
+        return TypicalEntries.getTypicalFeedsEntryBook();
     }
 
     /**
@@ -119,6 +129,13 @@ public abstract class EntryBookSystemTest {
      */
     protected Path getDataFileLocationArchivesEntryBook() {
         return TestApp.SAVE_LOCATION_ARCHIVES_ENTRYBOOK_FOR_TESTING;
+    }
+
+    /**
+     * Returns the directory of the data file for the feeds entry book.
+     */
+    protected Path getDataFileLocationFeedsEntryBook() {
+        return TestApp.SAVE_LOCATION_FEEDS_ENTRYBOOK_FOR_TESTING;
     }
 
     public MainWindowHandle getMainWindowHandle() {
@@ -222,6 +239,7 @@ public abstract class EntryBookSystemTest {
         assertEquals(expectedResultMessage, getResultDisplay().getText());
         assertEquals(new EntryBook(expectedModel.getListEntryBook()), testApp.readStorageListEntryBook());
         assertEquals(new EntryBook(expectedModel.getArchivesEntryBook()), testApp.readStorageArchivesEntryBook());
+        assertEquals(new EntryBook(expectedModel.getFeedsEntryBook()), testApp.readStorageFeedsEntryBook());
         assertEquals(expectedModel.getContext(), testApp.getModel().getContext());
         assertListMatching(getEntryListPanel(), expectedModel.getFilteredEntryList());
     }

--- a/src/test/java/systemtests/SystemTestSetupHelper.java
+++ b/src/test/java/systemtests/SystemTestSetupHelper.java
@@ -24,15 +24,19 @@ public class SystemTestSetupHelper {
     public TestApp setupApplication(
         Supplier<ReadOnlyEntryBook> listEntryBook,
         Supplier<ReadOnlyEntryBook> archivesEntryBook,
+        Supplier<ReadOnlyEntryBook> feedsEntryBook,
         Path saveFileLocationListEntryBook,
-        Path saveFileLocationArchivesEntryBook) {
+        Path saveFileLocationArchivesEntryBook,
+        Path saveFileLocationFeedsEntryBook) {
         try {
             FxToolkit.registerStage(Stage::new);
             FxToolkit.setupApplication(() -> testApp = new TestApp(
                                                             listEntryBook,
                                                             archivesEntryBook,
+                                                            feedsEntryBook,
                                                             saveFileLocationListEntryBook,
-                                                            saveFileLocationArchivesEntryBook));
+                                                            saveFileLocationArchivesEntryBook,
+                                                            saveFileLocationFeedsEntryBook));
         } catch (TimeoutException te) {
             throw new AssertionError("Application takes too long to set up.", te);
         }


### PR DESCRIPTION
Resolves #194.
Promotes clear command to archives and feeds context for ease of clearing.

### Summary of changes:
- Promotes clear command to archives and feeds context for ease of clearing
- Tautology is a tautology is a tautology